### PR TITLE
feat(auth): implement real AWS/GCP auth.validate and auth.whoami

### DIFF
--- a/internal/adapters/inbound/cli/auth_cmd_test.go
+++ b/internal/adapters/inbound/cli/auth_cmd_test.go
@@ -1,0 +1,87 @@
+// File: internal/adapters/inbound/cli/auth_cmd_test.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 15/03/2026
+// Purpose: Verifies auth CLI command provider wiring and renderer compatibility.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"multix/cmd/root"
+	appSkills "multix/internal/application/skills"
+	domainAuth "multix/internal/domain/auth"
+	domainSkills "multix/internal/domain/skills"
+)
+
+type captureSkill struct {
+	name       string
+	result     any
+	lastInput  map[string]any
+	execCalled bool
+}
+
+func (s *captureSkill) Name() string        { return s.name }
+func (s *captureSkill) Description() string { return s.name }
+func (s *captureSkill) InputSchema() any    { return map[string]any{} }
+func (s *captureSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	s.execCalled = true
+	s.lastInput = input
+	return s.result, nil
+}
+
+func TestAuthCLIProviderFlagWiring(t *testing.T) {
+	rootCmd := root.NewRootCmd()
+	registry := domainSkills.NewRegistry()
+	validateSkill := &captureSkill{name: "auth.validate", result: &domainAuth.ValidationResult{Provider: "gcp", Valid: true}}
+	whoamiSkill := &captureSkill{name: "auth.whoami", result: &domainAuth.Identity{Provider: "gcp", ProjectID: "demo"}}
+	registry.Register(validateSkill)
+	registry.Register(whoamiSkill)
+
+	executor := appSkills.NewExecutor(registry)
+	NewAuthHandler(rootCmd, executor).Register()
+
+	t.Run("auth validate forwards --provider", func(t *testing.T) {
+		rootCmd.SetArgs([]string{"auth", "validate", "--provider", "gcp", "--output", "json"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("unexpected command error: %v", err)
+		}
+		if !validateSkill.execCalled || validateSkill.lastInput["provider"] != "gcp" {
+			t.Fatalf("expected provider gcp passed to skill, got %+v", validateSkill.lastInput)
+		}
+	})
+
+	t.Run("auth whoami forwards --provider", func(t *testing.T) {
+		rootCmd.SetArgs([]string{"auth", "whoami", "--provider", "aws", "--output", "table"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("unexpected command error: %v", err)
+		}
+		if !whoamiSkill.execCalled || whoamiSkill.lastInput["provider"] != "aws" {
+			t.Fatalf("expected provider aws passed to skill, got %+v", whoamiSkill.lastInput)
+		}
+	})
+}
+
+func TestRenderAuthOutputs_JSONAndTable(t *testing.T) {
+	payload := &domainAuth.ValidationResult{Provider: "aws", Valid: true, Principal: "arn:aws:iam::123:user/demo"}
+
+	jsonBuf := &bytes.Buffer{}
+	if err := renderTo(jsonBuf, payload, "json"); err != nil {
+		t.Fatalf("json render failed: %v", err)
+	}
+	if !bytes.Contains(jsonBuf.Bytes(), []byte(`"provider": "aws"`)) {
+		t.Fatalf("unexpected json output: %s", jsonBuf.String())
+	}
+
+	tableBuf := &bytes.Buffer{}
+	if err := renderTo(tableBuf, payload, "table"); err != nil {
+		t.Fatalf("table render failed: %v", err)
+	}
+	if !bytes.Contains(tableBuf.Bytes(), []byte("provider")) {
+		t.Fatalf("unexpected table output: %s", tableBuf.String())
+	}
+}

--- a/internal/adapters/outbound/cloud/aws/adapter.go
+++ b/internal/adapters/outbound/cloud/aws/adapter.go
@@ -1,3 +1,10 @@
+// File: internal/adapters/outbound/cloud/aws/adapter.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 15/03/2026
+// Purpose: Implements AWS provider adapters, including real auth validation and identity via STS.
+
 package aws
 
 import (
@@ -47,70 +54,91 @@ func (a *adapter) ID() string {
 	return "aws"
 }
 
-// AuthProvider Implementations
+// Login implements the AuthProvider contract for legacy login compatibility.
 func (a *adapter) Login(ctx context.Context, creds auth.Credentials) (*auth.Session, error) {
 	a.logger.Info("Logging in to AWS (stub)")
 	return &auth.Session{Provider: "aws", IsValid: true}, nil
 }
 
+// Whoami returns the active AWS identity using STS GetCallerIdentity.
 func (a *adapter) Whoami(ctx context.Context) (*auth.Identity, error) {
 	a.logger.Info("Retrieving AWS caller identity")
-	client, err := a.stsClientFunc(ctx)
+	out, err := a.getCallerIdentity(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("aws config error: %w", err)
+		return nil, err
 	}
 
-	out, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		return nil, fmt.Errorf("aws sts error: %w", err)
-	}
-
-	principalType := "unknown"
-	arn := *out.Arn
-	if strings.Contains(arn, ":user/") {
-		principalType = "user"
-	} else if strings.Contains(arn, ":assumed-role/") {
-		principalType = "assumed-role"
-	}
-
-	return &auth.Identity{
-		Provider:      "aws",
-		AccountID:     *out.Account,
-		Principal:     arn,
-		PrincipalType: principalType,
-	}, nil
+	identity := mapAWSIdentity(out)
+	return &identity, nil
 }
 
+// Validate validates AWS credentials using STS GetCallerIdentity.
 func (a *adapter) Validate(ctx context.Context) (*auth.ValidationResult, error) {
 	a.logger.Info("Validating AWS credentials via STS")
+	out, err := a.getCallerIdentity(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	identity := mapAWSIdentity(out)
+	return &auth.ValidationResult{
+		Provider:  "aws",
+		Valid:     true,
+		AccountID: identity.AccountID,
+		Principal: identity.Principal,
+		Message:   "AWS credentials are valid",
+		Details: map[string]string{
+			"arn":            identity.Principal,
+			"principal_type": identity.PrincipalType,
+		},
+	}, nil
+}
+
+func (a *adapter) getCallerIdentity(ctx context.Context) (*sts.GetCallerIdentityOutput, error) {
 	client, err := a.stsClientFunc(ctx)
 	if err != nil {
-		return &auth.ValidationResult{
-			Provider: "aws",
-			IsValid:  false,
-			Message:  fmt.Sprintf("failed to load aws config: %v", err),
-		}, nil
+		return nil, fmt.Errorf("failed to load AWS config/credentials; run 'aws configure' or 'aws sso login': %w", err)
 	}
 
 	out, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
-		return &auth.ValidationResult{
-			Provider: "aws",
-			IsValid:  false,
-			Message:  fmt.Sprintf("failed GetCallerIdentity: %v", err),
-		}, nil
+		return nil, fmt.Errorf("failed AWS STS GetCallerIdentity; verify credentials/session are active: %w", err)
 	}
-
-	return &auth.ValidationResult{
-		Provider:  "aws",
-		IsValid:   true,
-		AccountID: *out.Account,
-		Principal: *out.Arn,
-		Message:   "AWS credentials are valid",
-	}, nil
+	return out, nil
 }
 
-// InventoryProvider Implementations
+func mapAWSIdentity(out *sts.GetCallerIdentityOutput) auth.Identity {
+	arn := awsString(out.Arn)
+	return auth.Identity{
+		Provider:      "aws",
+		AccountID:     awsString(out.Account),
+		Principal:     arn,
+		PrincipalType: inferAWSPrincipalType(arn),
+		UserID:        awsString(out.UserId),
+	}
+}
+
+func inferAWSPrincipalType(arn string) string {
+	switch {
+	case strings.Contains(arn, ":assumed-role/"):
+		return "role"
+	case strings.Contains(arn, ":role/"):
+		return "role"
+	case strings.Contains(arn, ":user/"):
+		return "user"
+	default:
+		return "unknown"
+	}
+}
+
+func awsString(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return *v
+}
+
+// List returns AWS inventory resources.
 func (a *adapter) List(ctx context.Context, resourceType string) ([]*inventory.Resource, error) {
 	a.logger.Info("Listing AWS inventory resources", "type", resourceType)
 	return []*inventory.Resource{
@@ -118,12 +146,13 @@ func (a *adapter) List(ctx context.Context, resourceType string) ([]*inventory.R
 	}, nil
 }
 
+// Scan summarizes AWS inventory resources.
 func (a *adapter) Scan(ctx context.Context) (*inventory.Summary, error) {
 	a.logger.Info("Scanning entire AWS account inventory")
 	return &inventory.Summary{ProviderName: "aws", Total: 15, CountByType: map[string]int{"EC2": 10, "S3": 5}}, nil
 }
 
-// K8sProvider Implementations
+// ListClusters returns EKS clusters.
 func (a *adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
 	a.logger.Info("Listing EKS clusters", "region", "us-east-1")
 	return []*k8s.Cluster{
@@ -131,6 +160,7 @@ func (a *adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
 	}, nil
 }
 
+// SyncContext syncs EKS context to kubeconfig.
 func (a *adapter) SyncContext(ctx context.Context, clusterName, region string) error {
 	a.logger.Info("Generating kubeconfig for EKS cluster", "cluster", clusterName)
 	return nil

--- a/internal/adapters/outbound/cloud/aws/adapter_test.go
+++ b/internal/adapters/outbound/cloud/aws/adapter_test.go
@@ -1,0 +1,71 @@
+// File: internal/adapters/outbound/cloud/aws/adapter_test.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 15/03/2026
+// Purpose: Tests AWS auth adapter normalization behavior without live cloud dependencies.
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/platform/logger"
+
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type fakeSTSClient struct {
+	output *sts.GetCallerIdentityOutput
+	err    error
+}
+
+func (f *fakeSTSClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.output, nil
+}
+
+func TestAWSAdapterValidateAndWhoami(t *testing.T) {
+	log := logger.New("info")
+	a := NewAdapter(log).(*adapter)
+
+	account := "123456789012"
+	arn := "arn:aws:sts::123456789012:assumed-role/Admin/session"
+	userID := "AIDAXXXXX"
+	a.stsClientFunc = func(ctx context.Context) (stsAPI, error) {
+		return &fakeSTSClient{output: &sts.GetCallerIdentityOutput{Account: &account, Arn: &arn, UserId: &userID}}, nil
+	}
+
+	result, err := a.Validate(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected validate error: %v", err)
+	}
+	if !result.Valid || result.AccountID != account || result.Principal != arn {
+		t.Fatalf("unexpected validate payload: %+v", result)
+	}
+
+	identity, err := a.Whoami(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected whoami error: %v", err)
+	}
+	if identity.PrincipalType != "role" || identity.UserID != userID {
+		t.Fatalf("unexpected identity payload: %+v", identity)
+	}
+}
+
+func TestAWSAdapterValidateErrors(t *testing.T) {
+	log := logger.New("info")
+	a := NewAdapter(log).(*adapter)
+	a.stsClientFunc = func(ctx context.Context) (stsAPI, error) {
+		return &fakeSTSClient{err: errors.New("expired token")}, nil
+	}
+
+	_, err := a.Validate(context.Background())
+	if err == nil {
+		t.Fatal("expected error when sts call fails")
+	}
+}

--- a/internal/adapters/outbound/cloud/gcp/adapter.go
+++ b/internal/adapters/outbound/cloud/gcp/adapter.go
@@ -1,8 +1,14 @@
+// File: internal/adapters/outbound/cloud/gcp/adapter.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 15/03/2026
+// Purpose: Implements GCP provider adapters, including real ADC-based auth validation and identity.
+
 package gcp
 
 import (
 	"context"
-
 	"encoding/json"
 	"fmt"
 
@@ -14,19 +20,27 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
+type findCredentialsFunc func(ctx context.Context, scopes ...string) (*google.Credentials, error)
+
+// Adapter implements GCP-backed outbound provider contracts.
 type Adapter struct {
-	log logger.Logger
+	log                 logger.Logger
+	findCredentialsFunc findCredentialsFunc
 }
 
+// NewAdapter creates a new GCP cloud adapter.
 func NewAdapter(log logger.Logger) *Adapter {
-	return &Adapter{log: log}
+	return &Adapter{
+		log:                 log.With("provider", "gcp"),
+		findCredentialsFunc: google.FindDefaultCredentials,
+	}
 }
 
 func (a *Adapter) ID() string {
 	return "gcp"
 }
 
-// AuthProvider Implementation
+// Login implements the AuthProvider contract for legacy login compatibility.
 func (a *Adapter) Login(ctx context.Context, creds auth.Credentials) (*auth.Session, error) {
 	a.log.Info("Authenticating via Google Cloud SDK (gcloud stub)", "provider", "gcp")
 	return &auth.Session{
@@ -35,55 +49,88 @@ func (a *Adapter) Login(ctx context.Context, creds auth.Credentials) (*auth.Sess
 	}, nil
 }
 
+// Validate checks whether ADC credentials are available and usable.
 func (a *Adapter) Validate(ctx context.Context) (*auth.ValidationResult, error) {
 	a.log.Info("Validating GCP application default credentials", "provider", "gcp")
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	creds, err := a.defaultCredentials(ctx)
 	if err != nil {
-		return &auth.ValidationResult{
-			Provider: "gcp",
-			IsValid:  false,
-			Message:  fmt.Sprintf("ADC not found or invalid: %v", err),
-		}, nil
+		return nil, err
 	}
 
-	return &auth.ValidationResult{
-		Provider:  "gcp",
-		IsValid:   true,
-		AccountID: creds.ProjectID,
-		Message:   "Valid application default credentials found",
-	}, nil
+	result := &auth.ValidationResult{
+		Provider: "gcp",
+		Valid:    true,
+		Message:  "GCP application default credentials are available",
+		Details: map[string]string{
+			"auth_source": inferAuthSource(creds),
+		},
+	}
+	if creds.ProjectID != "" {
+		result.AccountID = creds.ProjectID
+		result.Details["project_id"] = creds.ProjectID
+	}
+	return result, nil
 }
 
+// Whoami returns best-effort GCP identity details from active credentials context.
 func (a *Adapter) Whoami(ctx context.Context) (*auth.Identity, error) {
 	a.log.Info("Retrieving GCP active credentials context", "provider", "gcp")
-	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	creds, err := a.defaultCredentials(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+		return nil, err
 	}
 
-	principal := "unknown"
-	authSource := "application_default_credentials"
-
-	var credJSON map[string]any
-	if len(creds.JSON) > 0 {
-		if err := json.Unmarshal(creds.JSON, &credJSON); err == nil {
-			if email, ok := credJSON["client_email"].(string); ok {
-				principal = email
-				authSource = "service_account_key"
-			}
-		}
-	}
-
-	return &auth.Identity{
+	authSource := inferAuthSource(creds)
+	identity := &auth.Identity{
 		Provider:   "gcp",
-		AccountID:  creds.ProjectID,
 		ProjectID:  creds.ProjectID,
-		Principal:  principal,
+		AccountID:  creds.ProjectID,
 		AuthSource: authSource,
-	}, nil
+		Raw: map[string]any{
+			"credential_type": authSource,
+		},
+	}
+
+	if serviceAccountEmail := extractServiceAccountEmail(creds.JSON); serviceAccountEmail != "" {
+		identity.Principal = serviceAccountEmail
+		identity.PrincipalType = "service_account"
+		return identity, nil
+	}
+
+	identity.Note = "active credentials detected via ADC; principal identity is not directly resolvable for this credential source"
+	return identity, nil
 }
 
-// InventoryProvider Implementation
+func (a *Adapter) defaultCredentials(ctx context.Context) (*google.Credentials, error) {
+	creds, err := a.findCredentialsFunc(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve GCP application default credentials; run 'gcloud auth application-default login' or set GOOGLE_APPLICATION_CREDENTIALS: %w", err)
+	}
+	return creds, nil
+}
+
+func inferAuthSource(creds *google.Credentials) string {
+	if extractServiceAccountEmail(creds.JSON) != "" {
+		return "service_account_key"
+	}
+	return "application_default_credentials"
+}
+
+func extractServiceAccountEmail(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var credentialJSON map[string]any
+	if err := json.Unmarshal(raw, &credentialJSON); err != nil {
+		return ""
+	}
+
+	email, _ := credentialJSON["client_email"].(string)
+	return email
+}
+
+// Scan summarizes GCP inventory resources.
 func (a *Adapter) Scan(ctx context.Context) (*inventory.Summary, error) {
 	a.log.Info("Summarizing GCP inventory", "provider", "gcp")
 	return &inventory.Summary{
@@ -96,6 +143,7 @@ func (a *Adapter) Scan(ctx context.Context) (*inventory.Summary, error) {
 	}, nil
 }
 
+// List returns GCP inventory resources.
 func (a *Adapter) List(ctx context.Context, resourceType string) ([]*inventory.Resource, error) {
 	a.log.Info("Listing GCP inventory resources", "provider", "gcp", "type", resourceType)
 	return []*inventory.Resource{
@@ -104,7 +152,7 @@ func (a *Adapter) List(ctx context.Context, resourceType string) ([]*inventory.R
 	}, nil
 }
 
-// K8sProvider Implementation
+// ListClusters returns GKE clusters.
 func (a *Adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
 	a.log.Info("Listing GKE clusters", "provider", "gcp", "region", "us-central1")
 	return []*k8s.Cluster{
@@ -113,6 +161,7 @@ func (a *Adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
 	}, nil
 }
 
+// SyncContext syncs GKE context to kubeconfig.
 func (a *Adapter) SyncContext(ctx context.Context, clusterID string, region string) error {
 	a.log.Info("Syncing GKE context to kubeconfig", "cluster", clusterID, "region", region)
 	return nil

--- a/internal/adapters/outbound/cloud/gcp/adapter_test.go
+++ b/internal/adapters/outbound/cloud/gcp/adapter_test.go
@@ -1,0 +1,78 @@
+// File: internal/adapters/outbound/cloud/gcp/adapter_test.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 15/03/2026
+// Purpose: Tests GCP auth adapter best-effort identity normalization without live cloud dependencies.
+
+package gcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/platform/logger"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+func TestGCPAdapterValidateAndWhoami_ServiceAccount(t *testing.T) {
+	log := logger.New("info")
+	a := NewAdapter(log)
+	a.findCredentialsFunc = func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+		return &google.Credentials{
+			ProjectID: "demo-project",
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: "token",
+			}),
+			JSON: []byte(`{"client_email":"bot@demo-project.iam.gserviceaccount.com"}`),
+		}, nil
+	}
+
+	result, err := a.Validate(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected validate error: %v", err)
+	}
+	if !result.Valid || result.AccountID != "demo-project" {
+		t.Fatalf("unexpected validate result: %+v", result)
+	}
+
+	identity, err := a.Whoami(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected whoami error: %v", err)
+	}
+	if identity.Principal != "bot@demo-project.iam.gserviceaccount.com" || identity.PrincipalType != "service_account" {
+		t.Fatalf("unexpected identity: %+v", identity)
+	}
+}
+
+func TestGCPAdapterWhoami_BestEffortFallback(t *testing.T) {
+	log := logger.New("info")
+	a := NewAdapter(log)
+	a.findCredentialsFunc = func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+		return &google.Credentials{ProjectID: "demo-project"}, nil
+	}
+
+	identity, err := a.Whoami(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if identity.Principal != "" || identity.Note == "" || identity.AuthSource == "" {
+		t.Fatalf("expected best-effort fallback identity fields, got %+v", identity)
+	}
+}
+
+func TestGCPAdapterValidateErrors(t *testing.T) {
+	log := logger.New("info")
+	a := NewAdapter(log)
+	a.findCredentialsFunc = func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+		return nil, errors.New("no adc")
+	}
+
+	_, err := a.Validate(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/application/auth/auth_skills.go
+++ b/internal/application/auth/auth_skills.go
@@ -9,11 +9,14 @@ package auth
 
 import (
 	"context"
+	"strings"
 
 	domainAuth "multix/internal/domain/auth"
 	"multix/internal/domain/skills"
-	"multix/internal/ports/outbound" // Import for ProviderRegistry
+	"multix/internal/ports/outbound"
 )
+
+const defaultCloudProvider = "aws"
 
 // ValidateSkill validates if the user's current cloud provider credentials are valid and active.
 type ValidateSkill struct {
@@ -38,12 +41,11 @@ func (s *ValidateSkill) InputSchema() any {
 				"description": "Cloud provider name (aws, gcp, azure, etc.)",
 			},
 		},
-		"required": []string{"provider"},
 	}
 }
 
 func (s *ValidateSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
-	providerName, _ := input["provider"].(string)
+	providerName := resolveProvider(input)
 	p, err := s.providers.GetCloudAuthProvider(providerName)
 	if err != nil {
 		return nil, err
@@ -51,12 +53,7 @@ func (s *ValidateSkill) Execute(ctx context.Context, input map[string]any) (any,
 
 	result, err := p.Validate(ctx)
 	if err != nil {
-		// Fallback for explicit errors that weren't mapped into a ValidationResult by the provider.
-		return &domainAuth.ValidationResult{
-			Provider: providerName,
-			IsValid:  false,
-			Message:  err.Error(),
-		}, nil
+		return nil, err
 	}
 	return result, nil
 }
@@ -81,12 +78,11 @@ func (s *WhoamiSkill) InputSchema() any {
 		"properties": map[string]any{
 			"provider": map[string]any{"type": "string"},
 		},
-		"required": []string{"provider"},
 	}
 }
 
 func (s *WhoamiSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
-	providerName, _ := input["provider"].(string)
+	providerName := resolveProvider(input)
 	p, err := s.providers.GetCloudAuthProvider(providerName)
 	if err != nil {
 		return nil, err
@@ -128,4 +124,12 @@ func (s *LoginSkill) Execute(ctx context.Context, input map[string]any) (any, er
 
 	session, valErr := p.Login(ctx, domainAuth.Credentials{})
 	return map[string]any{"provider": session.Provider, "valid": session.IsValid}, valErr
+}
+
+func resolveProvider(input map[string]any) string {
+	providerName, _ := input["provider"].(string)
+	if strings.TrimSpace(providerName) == "" {
+		return defaultCloudProvider
+	}
+	return providerName
 }

--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -35,6 +35,7 @@ func BuildApp() (*App, error) {
 	cfg := LoadConfig()
 	log := logger.New("info")
 	rootCmd := root.NewRootCmd()
+	applyRuntimeDefaults(rootCmd, cfg)
 
 	providers := BuildProviderRegistry(log)
 	skillRegistry := BuildSkillRegistry(providers)
@@ -66,4 +67,9 @@ func (a *App) Wire() *cobra.Command {
 
 	root.RegisterVersionCmd(a.RootCmd)
 	return a.RootCmd
+}
+
+func applyRuntimeDefaults(rootCmd *cobra.Command, cfg *config.Config) {
+	_ = rootCmd.PersistentFlags().Set("provider", cfg.DefaultCloudProvider)
+	_ = rootCmd.PersistentFlags().Set("output", cfg.DefaultOutputMode)
 }

--- a/internal/domain/auth/models.go
+++ b/internal/domain/auth/models.go
@@ -1,3 +1,10 @@
+// File: internal/domain/auth/models.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 15/03/2026
+// Purpose: Defines provider-agnostic authentication models used by skills and adapters.
+
 package auth
 
 import "time"
@@ -22,7 +29,7 @@ type Session struct {
 // ValidationResult represents the outcome of a provider validation check.
 type ValidationResult struct {
 	Provider  string            `json:"provider"`
-	IsValid   bool              `json:"is_valid"`
+	Valid     bool              `json:"valid"`
 	AccountID string            `json:"account_id,omitempty"`
 	Principal string            `json:"principal,omitempty"`
 	Message   string            `json:"message,omitempty"`
@@ -35,7 +42,9 @@ type Identity struct {
 	AccountID     string         `json:"account_id,omitempty"`
 	Principal     string         `json:"principal,omitempty"`
 	PrincipalType string         `json:"principal_type,omitempty"`
+	UserID        string         `json:"user_id,omitempty"`
 	ProjectID     string         `json:"project_id,omitempty"`
 	AuthSource    string         `json:"auth_source,omitempty"`
+	Note          string         `json:"note,omitempty"`
 	Raw           map[string]any `json:"raw,omitempty"`
 }

--- a/test/auth_skills_test.go
+++ b/test/auth_skills_test.go
@@ -16,7 +16,7 @@ import (
 	domainAuth "multix/internal/domain/auth"
 )
 
-// mockAuthProvider is a test double for outbound.AuthProvider
+// mockAuthProvider is a test double for outbound.AuthProvider.
 type mockAuthProvider struct {
 	id             string
 	validateResult *domainAuth.ValidationResult
@@ -43,7 +43,7 @@ func TestAuthSkills_Execution(t *testing.T) {
 		id: "aws",
 		validateResult: &domainAuth.ValidationResult{
 			Provider:  "aws",
-			IsValid:   true,
+			Valid:     true,
 			AccountID: "12345",
 			Principal: "arn:mock",
 		},
@@ -56,7 +56,7 @@ func TestAuthSkills_Execution(t *testing.T) {
 	}
 	providers.RegisterAuth("aws", mockAWS)
 
-	t.Run("auth.validate execution with known provider", func(t *testing.T) {
+	t.Run("auth.validate execution with explicit provider", func(t *testing.T) {
 		skill := auth.NewValidateSkill(providers)
 		input := map[string]any{"provider": "aws"}
 
@@ -66,12 +66,12 @@ func TestAuthSkills_Execution(t *testing.T) {
 		}
 
 		result, ok := res.(*domainAuth.ValidationResult)
-		if !ok || result.Provider != "aws" || !result.IsValid {
+		if !ok || result.Provider != "aws" || !result.Valid {
 			t.Errorf("expected valid aws ValidationResult, got %+v", res)
 		}
 	})
 
-	t.Run("auth.whoami execution with known provider", func(t *testing.T) {
+	t.Run("auth.whoami execution with explicit provider", func(t *testing.T) {
 		skill := auth.NewWhoamiSkill(providers)
 		input := map[string]any{"provider": "aws"}
 
@@ -86,8 +86,32 @@ func TestAuthSkills_Execution(t *testing.T) {
 		}
 	})
 
+	t.Run("auth.validate falls back to default provider when omitted", func(t *testing.T) {
+		skill := auth.NewValidateSkill(providers)
+
+		res, err := skill.Execute(context.Background(), map[string]any{})
+		if err != nil {
+			t.Fatalf("unexpected error with default provider: %v", err)
+		}
+
+		result := res.(*domainAuth.ValidationResult)
+		if result.Provider != "aws" {
+			t.Fatalf("expected default provider aws, got %q", result.Provider)
+		}
+	})
+
 	t.Run("auth.validate with unknown provider returns error", func(t *testing.T) {
 		skill := auth.NewValidateSkill(providers)
+		input := map[string]any{"provider": "unknown"}
+
+		_, err := skill.Execute(context.Background(), input)
+		if err == nil {
+			t.Fatal("expected error for unknown provider, got nil")
+		}
+	})
+
+	t.Run("auth.whoami with unknown provider returns error", func(t *testing.T) {
+		skill := auth.NewWhoamiSkill(providers)
 		input := map[string]any{"provider": "unknown"}
 
 		_, err := skill.Execute(context.Background(), input)


### PR DESCRIPTION
### Motivation

- Make `auth.validate` and `auth.whoami` real, usable skills for AWS and GCP while preserving the existing Skills‑First + ProviderRegistry patterns.
- Provide pragmatic, truthful identity and validation outputs (no fake fields) suitable for CLI and future agent/tool usage.

### Description

- Implemented AWS auth adapter using AWS SDK v2 STS `GetCallerIdentity` to power `Validate` and `Whoami`, with normalized mapping into `domain/auth.Identity` and `domain/auth.ValidationResult` and actionable error messages (`internal/adapters/outbound/cloud/aws/adapter.go`).
- Implemented GCP auth adapter using Application Default Credentials (`google.FindDefaultCredentials`) with best‑effort principal extraction (service account email when present), `project_id` propagation, `auth_source` and informative fallback `note` (`internal/adapters/outbound/cloud/gcp/adapter.go`).
- Evolved domain auth models to normalize fields: `ValidationResult.Valid` (replacing `IsValid` shape), added `Identity.UserID` and `Identity.Note` to support provider outputs (`internal/domain/auth/models.go`).
- Kept skills-first execution and provider resolution via `ProviderRegistry` and added default provider fallback when `provider` is omitted in skill input (`auth.validate` / `auth.whoami` resolve default to `aws`) (`internal/application/auth/auth_skills.go`).
- Apply runtime defaults from bootstrap config onto root persistent flags so CLI defaults (`provider`, `output`) reflect bootstrap config (`internal/bootstrap/app.go`).
- Added focused unit tests for: skill-level behavior (provider resolution & default fallback), AWS adapter normalization and error handling (with fake STS client), GCP adapter best-effort normalization and failure handling (using test seams), and lightweight CLI tests validating `--provider` wiring and JSON/table rendering (`test/*`, `internal/adapters/outbound/cloud/*_test.go`, `internal/adapters/inbound/cli/auth_cmd_test.go`).

### Testing

- Ran formatting and static checks: `make fmt` (passed), `make vet` (passed).
- Ran unit tests: `make test` — all new and existing tests passed (adapter tests, skill tests, CLI tests reported as passing in test output).
- Built the CLI binary: `make build` (passed and produced `build/multix`).

All changes are implemented with small, focused diffs and preserve existing architecture and CLI rendering behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b73557c3688325b8cfbcf57d3f9fc1)