### PR TITLE
v0.6 — k8s.list_clusters: real EKS, GKE, OKE listing (#11 #12 #13)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.100.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
 	github.com/google/uuid v1.6.0
-	github.com/oracle/oci-go-sdk/v65 v65.109.1
+	github.com/oracle/oci-go-sdk/v65 v65.114.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/oauth2 v0.36.0
 )
@@ -33,6 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 // indirect
@@ -56,6 +57,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1 h1:gQ9fSyFk3Y9Vm2fVbphBeJfXJlkJvEvC35TszBVjprg=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1/go.mod h1:Y95W0Hm6FYLPa6o0hbnJ+sWgmdc4ifcLFjGkdobWVhY=
+github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=
+github.com/aws/aws-sdk-go-v2/service/eks v1.83.0/go.mod h1:JQcyECIV9iZHm+GMrWn1pTPTJYRavOVsqPvlCbjt+Fg=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9/go.mod h1:w7wZ/s9qK7c8g4al+UyoF1Sp/Z45UwMGcqIzLWVQHWk=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 h1:ieLCO1JxUWuxTZ1cRd0GAaeX7O6cIxnwk7tc1LsQhC4=
@@ -97,6 +99,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/oracle/oci-go-sdk/v65 v65.109.1 h1:AWawOPlhpDJnpxNxwPB+5xueKVSdpuB3jDHhKFEe724=
 github.com/oracle/oci-go-sdk/v65 v65.109.1/go.mod h1:8ZzvzuEG/cFLFZhxg/Mg1w19KqyXBKO3c17QIc5PkGs=
+github.com/oracle/oci-go-sdk/v65 v65.114.0 h1:7LvSJwXebrQ/iasML0ff1wcVN38rE0ZMzRo2Zg6dhjA=
+github.com/oracle/oci-go-sdk/v65 v65.114.0/go.mod h1:oo33NDf2XPqx3/N6oLG4jFlrqJ0xu4Rlt9SfuAbtDFs=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -104,6 +108,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
 github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/adapters/outbound/cloud/aws/adapter.go
+++ b/internal/adapters/outbound/cloud/aws/adapter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -34,6 +35,8 @@ type adapter struct {
 	ec2ClientFunc func(ctx context.Context) (ec2API, string, error)
 	// s3ClientFunc allows testable seams for S3 listing.
 	s3ClientFunc func(ctx context.Context) (s3API, error)
+	// eksClusterListFunc lists EKS clusters in the active region.
+	eksClusterListFunc func(ctx context.Context) ([]*k8s.Cluster, error)
 }
 
 type stsAPI interface {
@@ -54,7 +57,7 @@ func NewAdapter(log logger.Logger) interface {
 	outbound.InventoryProvider
 	outbound.K8sProvider
 } {
-	return &adapter{
+	a := &adapter{
 		logger: log.With("provider", "aws"),
 		stsClientFunc: func(ctx context.Context) (stsAPI, error) {
 			cfg, err := config.LoadDefaultConfig(ctx)
@@ -78,6 +81,48 @@ func NewAdapter(log logger.Logger) interface {
 			return s3.NewFromConfig(cfg), nil
 		},
 	}
+	a.eksClusterListFunc = a.defaultEKSList
+	return a
+}
+
+func (a *adapter) defaultEKSList(ctx context.Context) ([]*k8s.Cluster, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	client := eks.NewFromConfig(cfg)
+	region := cfg.Region
+
+	var clusters []*k8s.Cluster
+	var nextToken *string
+	for {
+		out, err := client.ListClusters(ctx, &eks.ListClustersInput{NextToken: nextToken})
+		if err != nil {
+			return nil, fmt.Errorf("EKS ListClusters failed: %w", err)
+		}
+		for _, name := range out.Clusters {
+			descOut, err := client.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: &name})
+			if err != nil {
+				return nil, fmt.Errorf("EKS DescribeCluster %q failed: %w", name, err)
+			}
+			c := descOut.Cluster
+			cluster := &k8s.Cluster{
+				ID:     awsString(c.Arn),
+				Name:   awsString(c.Name),
+				Region: region,
+				Status: string(c.Status),
+			}
+			if c.Version != nil {
+				cluster.Version = *c.Version
+			}
+			clusters = append(clusters, cluster)
+		}
+		if out.NextToken == nil || *out.NextToken == "" {
+			break
+		}
+		nextToken = out.NextToken
+	}
+	return clusters, nil
 }
 
 func (a *adapter) ID() string {
@@ -314,12 +359,10 @@ func mapS3Bucket(b s3types.Bucket, accountID string) *inventory.Resource {
 	return r
 }
 
-// ListClusters returns EKS clusters.
+// ListClusters returns EKS clusters in the active region.
 func (a *adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
-	a.logger.Info("Listing EKS clusters", "region", "us-east-1")
-	return []*k8s.Cluster{
-		{ID: "c-1", Name: "prod-eks-cluster", Region: "us-east-1", Status: "ACTIVE", Version: "1.30", NodeCount: 12},
-	}, nil
+	a.logger.Info("Listing EKS clusters")
+	return a.eksClusterListFunc(ctx)
 }
 
 // SyncContext syncs EKS context to kubeconfig.

--- a/internal/adapters/outbound/cloud/aws/k8s_test.go
+++ b/internal/adapters/outbound/cloud/aws/k8s_test.go
@@ -1,0 +1,41 @@
+// File: internal/adapters/outbound/cloud/aws/k8s_test.go
+// Purpose: Tests AWS EKS cluster listing without live cloud dependencies.
+
+package aws
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/k8s"
+	"multix/internal/platform/logger"
+)
+
+func TestAWSAdapter_ListClusters(t *testing.T) {
+	a := NewAdapter(logger.New("info")).(*adapter)
+	a.eksClusterListFunc = func(ctx context.Context) ([]*k8s.Cluster, error) {
+		return []*k8s.Cluster{
+			{ID: "arn:aws:eks:us-east-1:123:cluster/prod", Name: "prod", Region: "us-east-1", Status: "ACTIVE", Version: "1.30"},
+			{ID: "arn:aws:eks:us-east-1:123:cluster/dev", Name: "dev", Region: "us-east-1", Status: "CREATING", Version: "1.29"},
+		}, nil
+	}
+
+	clusters, err := a.ListClusters(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clusters) != 2 || clusters[0].Name != "prod" || clusters[1].Status != "CREATING" {
+		t.Fatalf("unexpected clusters: %+v", clusters)
+	}
+}
+
+func TestAWSAdapter_ListClusters_Error(t *testing.T) {
+	a := NewAdapter(logger.New("info")).(*adapter)
+	a.eksClusterListFunc = func(ctx context.Context) ([]*k8s.Cluster, error) {
+		return nil, errors.New("access denied")
+	}
+	if _, err := a.ListClusters(context.Background()); err == nil {
+		t.Fatal("expected error from EKS listing failure")
+	}
+}

--- a/internal/adapters/outbound/cloud/gcp/adapter.go
+++ b/internal/adapters/outbound/cloud/gcp/adapter.go
@@ -24,6 +24,7 @@ import (
 	"cloud.google.com/go/storage"
 	"golang.org/x/oauth2/google"
 	compute "google.golang.org/api/compute/v1"
+	container "google.golang.org/api/container/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -57,6 +58,8 @@ type Adapter struct {
 	computeListFunc func(ctx context.Context, projectID string) ([]gcpInstance, error)
 	// storageListFunc lists Cloud Storage buckets for a project.
 	storageListFunc func(ctx context.Context, projectID string) ([]gcpBucket, error)
+	// gkeClusterListFunc lists GKE clusters across all locations for a project.
+	gkeClusterListFunc func(ctx context.Context, projectID string) ([]*k8s.Cluster, error)
 }
 
 // NewAdapter creates a new GCP cloud adapter.
@@ -70,7 +73,36 @@ func NewAdapter(log logger.Logger) *Adapter {
 	}
 	a.computeListFunc = a.defaultComputeList
 	a.storageListFunc = a.defaultStorageList
+	a.gkeClusterListFunc = a.defaultGKEList
 	return a
+}
+
+func (a *Adapter) defaultGKEList(ctx context.Context, projectID string) ([]*k8s.Cluster, error) {
+	creds, err := a.defaultCredentials(ctx)
+	if err != nil {
+		return nil, err
+	}
+	svc, err := container.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize GKE service: %w", err)
+	}
+	parent := fmt.Sprintf("projects/%s/locations/-", projectID)
+	resp, err := svc.Projects.Locations.Clusters.List(parent).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("GKE Clusters.List failed: %w", err)
+	}
+	clusters := make([]*k8s.Cluster, 0, len(resp.Clusters))
+	for _, c := range resp.Clusters {
+		clusters = append(clusters, &k8s.Cluster{
+			ID:        c.Id,
+			Name:      c.Name,
+			Region:    c.Location,
+			Status:    c.Status,
+			Version:   c.CurrentMasterVersion,
+			NodeCount: int(c.CurrentNodeCount),
+		})
+	}
+	return clusters, nil
 }
 
 func (a *Adapter) defaultComputeList(ctx context.Context, projectID string) ([]gcpInstance, error) {
@@ -411,13 +443,14 @@ func regionFromZone(zone string) string {
 	return zone
 }
 
-// ListClusters returns GKE clusters.
+// ListClusters returns GKE clusters across all locations for the active project.
 func (a *Adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
-	a.log.Info("Listing GKE clusters", "region", "us-central1")
-	return []*k8s.Cluster{
-		{ID: "c-111", Name: "gke-autopilot-prod", Region: "us-central1", Version: "1.29", NodeCount: 0, Status: "RUNNING"},
-		{ID: "c-222", Name: "gke-standard-dev", Region: "us-east4", Version: "1.28", NodeCount: 5, Status: "RUNNING"},
-	}, nil
+	a.log.Info("Listing GKE clusters")
+	projectID, err := a.resolveProjectID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return a.gkeClusterListFunc(ctx, projectID)
 }
 
 // SyncContext syncs GKE context to kubeconfig.

--- a/internal/adapters/outbound/cloud/gcp/k8s_test.go
+++ b/internal/adapters/outbound/cloud/gcp/k8s_test.go
@@ -1,0 +1,56 @@
+// File: internal/adapters/outbound/cloud/gcp/k8s_test.go
+// Purpose: Tests GCP GKE cluster listing without live cloud dependencies.
+
+package gcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/k8s"
+	"multix/internal/platform/logger"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+func newAdapterWithGKEFake(clusters []*k8s.Cluster, projectID string, listErr error) *Adapter {
+	a := NewAdapter(logger.New("info"))
+	a.findCredentialsFunc = func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
+		return &google.Credentials{
+			ProjectID:   projectID,
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "x"}),
+		}, nil
+	}
+	a.execCmdFunc = mockExecFail
+	a.gkeClusterListFunc = func(ctx context.Context, p string) ([]*k8s.Cluster, error) {
+		if listErr != nil {
+			return nil, listErr
+		}
+		return clusters, nil
+	}
+	return a
+}
+
+func TestGCPAdapter_ListClusters(t *testing.T) {
+	a := newAdapterWithGKEFake([]*k8s.Cluster{
+		{ID: "111", Name: "gke-prod", Region: "us-central1", Status: "RUNNING", Version: "1.30.1", NodeCount: 5},
+		{ID: "222", Name: "gke-autopilot", Region: "us-east1", Status: "RUNNING", Version: "1.30.1"},
+	}, "demo-project", nil)
+
+	clusters, err := a.ListClusters(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clusters) != 2 || clusters[0].Name != "gke-prod" || clusters[0].NodeCount != 5 {
+		t.Fatalf("unexpected clusters: %+v", clusters)
+	}
+}
+
+func TestGCPAdapter_ListClusters_Error(t *testing.T) {
+	a := newAdapterWithGKEFake(nil, "demo-project", errors.New("access denied"))
+	if _, err := a.ListClusters(context.Background()); err == nil {
+		t.Fatal("expected error from GKE listing failure")
+	}
+}

--- a/internal/adapters/outbound/cloud/oci/adapter.go
+++ b/internal/adapters/outbound/cloud/oci/adapter.go
@@ -20,6 +20,7 @@ import (
 	"multix/internal/ports/outbound"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/containerengine"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/oracle/oci-go-sdk/v65/identity"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
@@ -53,6 +54,8 @@ type adapter struct {
 	computeListFunc func(ctx context.Context, cfg common.ConfigurationProvider, compartmentID string) ([]ociInstance, error)
 	// bucketListFunc lists Object Storage buckets under a compartment.
 	bucketListFunc func(ctx context.Context, cfg common.ConfigurationProvider, compartmentID string) ([]ociBucket, error)
+	// okeClusterListFunc lists OKE clusters under a compartment.
+	okeClusterListFunc func(ctx context.Context, cfg common.ConfigurationProvider, compartmentID string) ([]*k8s.Cluster, error)
 }
 
 // identityAPI defines the interface we need from OCI's identity client to make testing easier.
@@ -81,7 +84,40 @@ func NewAdapter(log logger.Logger) interface {
 	}
 	a.computeListFunc = defaultComputeList
 	a.bucketListFunc = defaultBucketList
+	a.okeClusterListFunc = defaultOKEList
 	return a
+}
+
+func defaultOKEList(ctx context.Context, cfg common.ConfigurationProvider, compartmentID string) ([]*k8s.Cluster, error) {
+	client, err := containerengine.NewContainerEngineClientWithConfigurationProvider(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize OKE client: %w", err)
+	}
+	region, _ := cfg.Region()
+
+	var out []*k8s.Cluster
+	var page *string
+	for {
+		req := containerengine.ListClustersRequest{CompartmentId: common.String(compartmentID), Page: page}
+		resp, err := client.ListClusters(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("OKE ListClusters failed: %w", err)
+		}
+		for _, c := range resp.Items {
+			out = append(out, &k8s.Cluster{
+				ID:      stringValue(c.Id),
+				Name:    stringValue(c.Name),
+				Region:  region,
+				Status:  string(c.LifecycleState),
+				Version: stringValue(c.KubernetesVersion),
+			})
+		}
+		if resp.OpcNextPage == nil || *resp.OpcNextPage == "" {
+			break
+		}
+		page = resp.OpcNextPage
+	}
+	return out, nil
 }
 
 func defaultComputeList(ctx context.Context, cfg common.ConfigurationProvider, compartmentID string) ([]ociInstance, error) {
@@ -367,12 +403,15 @@ func (a *adapter) listBuckets(ctx context.Context, cfg common.ConfigurationProvi
 	return resources, nil
 }
 
-// ListClusters returns OKE clusters (stub).
+// ListClusters returns OKE clusters under the active tenancy compartment.
 func (a *adapter) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
-	a.logger.Info("Listing OKE clusters", "region", "us-ashburn-1")
-	return []*k8s.Cluster{
-		{ID: "ocid1.cluster.oc1..abc", Name: "prod-oke-cluster", Region: "us-ashburn-1", Status: "ACTIVE", Version: "v1.30.1", NodeCount: 6},
-	}, nil
+	a.logger.Info("Listing OKE clusters")
+	cfg := a.cfgProviderFunc()
+	tenancyID, err := cfg.TenancyOCID()
+	if err != nil {
+		return nil, fmt.Errorf("invalid OCI configuration (missing tenancy): %w", err)
+	}
+	return a.okeClusterListFunc(ctx, cfg, tenancyID)
 }
 
 // SyncContext syncs OKE context to kubeconfig (stub).

--- a/internal/adapters/outbound/cloud/oci/k8s_test.go
+++ b/internal/adapters/outbound/cloud/oci/k8s_test.go
@@ -1,0 +1,59 @@
+// File: internal/adapters/outbound/cloud/oci/k8s_test.go
+// Purpose: Tests OCI OKE cluster listing without live cloud dependencies.
+
+package oci
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/k8s"
+	"multix/internal/platform/logger"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+func TestOCIAdapter_ListClusters(t *testing.T) {
+	a := NewAdapter(logger.New("info")).(*adapter)
+	a.cfgProviderFunc = func() common.ConfigurationProvider {
+		return &mockConfigProvider{tenancyID: "ocid1.tenancy.oc1..t"}
+	}
+	a.okeClusterListFunc = func(ctx context.Context, cfg common.ConfigurationProvider, c string) ([]*k8s.Cluster, error) {
+		return []*k8s.Cluster{
+			{ID: "ocid1.cluster.oc1..a", Name: "prod-oke", Region: "us-ashburn-1", Status: "ACTIVE", Version: "v1.30.1"},
+			{ID: "ocid1.cluster.oc1..b", Name: "dev-oke", Region: "us-ashburn-1", Status: "CREATING"},
+		}, nil
+	}
+
+	clusters, err := a.ListClusters(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(clusters) != 2 || clusters[0].Name != "prod-oke" || clusters[1].Status != "CREATING" {
+		t.Fatalf("unexpected clusters: %+v", clusters)
+	}
+}
+
+func TestOCIAdapter_ListClusters_Error(t *testing.T) {
+	a := NewAdapter(logger.New("info")).(*adapter)
+	a.cfgProviderFunc = func() common.ConfigurationProvider {
+		return &mockConfigProvider{tenancyID: "ocid1.tenancy.oc1..t"}
+	}
+	a.okeClusterListFunc = func(ctx context.Context, cfg common.ConfigurationProvider, c string) ([]*k8s.Cluster, error) {
+		return nil, errors.New("not authorized")
+	}
+	if _, err := a.ListClusters(context.Background()); err == nil {
+		t.Fatal("expected error from OKE listing failure")
+	}
+}
+
+func TestOCIAdapter_ListClusters_TenancyMissing(t *testing.T) {
+	a := NewAdapter(logger.New("info")).(*adapter)
+	a.cfgProviderFunc = func() common.ConfigurationProvider {
+		return &mockConfigProvider{err: errors.New("missing tenancy")}
+	}
+	if _, err := a.ListClusters(context.Background()); err == nil {
+		t.Fatal("expected error when tenancy OCID is missing")
+	}
+}


### PR DESCRIPTION
## Summary
Replace stub \`ListClusters\` in all three cloud adapters with real SDK calls so the existing \`k8s.list_clusters\` skill returns live data.

- **#11 AWS EKS** — \`ListClusters\` (paginated) + \`DescribeCluster\` per name; ARN as ID, region from active config.
- **#12 GCP GKE** — \`Projects.Locations.Clusters.List\` with \`locations="-"\` to fetch every region/zone in one call; current node count and master version mapped through.
- **#13 OCI OKE** — \`containerengine.ListClusters\` under tenancy compartment, paginated.

Same testable-seam pattern as v0.5: each adapter exposes a typed \`*ClusterListFunc\` returning \`[]*k8s.Cluster\` directly, so tests need no SDK wiring.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` — all green
- [x] \`make test-race\` — all green
- [x] 7 new unit tests across AWS/GCP/OCI (happy path, error propagation, missing-tenancy guard)
- [ ] Live smoke (manual, requires creds): \`multix k8s list-clusters --provider aws|gcp|oci\`

## Notes
Branched from \`feature/v0.5-cloud-inventory-claude\` (PR #50) since both share the SDK deps. If #50 lands first, this rebases cleanly onto main; if #50 stays open, this can land directly because the changes are additive (new file fields + new methods, no overlap).

---

Closes #11
Closes #12
Closes #13