### PR TITLE
v0.7 — Audit & Doctor Skills: doctor.auth, doctor.k8s, landingzone, security, cost (#14 #15 #16 #17 #18)

### DIFF
--- a/internal/application/cost/quick_scan_skill.go
+++ b/internal/application/cost/quick_scan_skill.go
@@ -1,0 +1,92 @@
+// File: internal/application/cost/quick_scan_skill.go
+// Purpose: Implements the cost.quick-scan skill — resource-count proxy as a v1 cost signal.
+
+package cost
+
+import (
+	"context"
+
+	"multix/internal/domain/skills"
+	"multix/internal/ports/outbound"
+)
+
+// QuickScanSkill produces a fast cost signal by aggregating inventory counts
+// per provider and resource type. It is explicitly a *resource-count proxy*,
+// not a billing query — full Cost Explorer / Billing API integration is
+// scoped to a follow-up issue (FOCUS-aligned cost.focus_report skill).
+type QuickScanSkill struct {
+	providers outbound.ProviderRegistry
+}
+
+// NewQuickScanSkill creates a new QuickScanSkill.
+func NewQuickScanSkill(pr outbound.ProviderRegistry) skills.Skill {
+	return &QuickScanSkill{providers: pr}
+}
+
+func (s *QuickScanSkill) Name() string { return "cost.quick_scan" }
+func (s *QuickScanSkill) Description() string {
+	return "Fast cost signal: aggregates inventory resource counts per provider as a proxy. Real billing queries are scoped to cost.focus_report (#46)."
+}
+func (s *QuickScanSkill) InputSchema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"providers": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		},
+	}
+}
+
+func (s *QuickScanSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	requested := extractProviders(input)
+	report := make([]map[string]any, 0, len(requested))
+	grandTotal := 0
+	for _, name := range requested {
+		entry := map[string]any{"provider": name}
+		p, err := s.providers.GetCloudInventoryProvider(name)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		summary, err := p.Scan(ctx)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		entry["ok"] = true
+		entry["total"] = summary.Total
+		entry["count_by_type"] = summary.CountByType
+		grandTotal += summary.Total
+		report = append(report, entry)
+	}
+	return map[string]any{
+		"note":             "resource-count proxy; not a billing query (see #46 for cost.focus_report)",
+		"grand_total":      grandTotal,
+		"providers":        report,
+	}, nil
+}
+
+func extractProviders(input map[string]any) []string {
+	defaults := []string{"aws", "gcp", "oci"}
+	raw, ok := input["providers"]
+	if !ok || raw == nil {
+		return defaults
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return defaults
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return defaults
+	}
+	return out
+}

--- a/internal/application/cost/quick_scan_skill_test.go
+++ b/internal/application/cost/quick_scan_skill_test.go
@@ -1,0 +1,79 @@
+// File: internal/application/cost/quick_scan_skill_test.go
+package cost
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/inventory"
+	"multix/internal/ports/outbound"
+)
+
+type fakeInv struct {
+	summary *inventory.Summary
+	err     error
+}
+
+func (f *fakeInv) ID() string { return "" }
+func (f *fakeInv) List(ctx context.Context, t string) ([]*inventory.Resource, error) {
+	return nil, nil
+}
+func (f *fakeInv) Scan(ctx context.Context) (*inventory.Summary, error) {
+	return f.summary, f.err
+}
+
+type fakeRegistry struct {
+	inv map[string]outbound.InventoryProvider
+}
+
+func (f *fakeRegistry) GetCloudAuthProvider(name string) (outbound.AuthProvider, error) {
+	return nil, errors.New("not used")
+}
+func (f *fakeRegistry) GetCloudInventoryProvider(name string) (outbound.InventoryProvider, error) {
+	if p, ok := f.inv[name]; ok {
+		return p, nil
+	}
+	return nil, errors.New("unknown provider")
+}
+func (f *fakeRegistry) GetKubernetesProvider(name string) (outbound.K8sProvider, error) {
+	return nil, errors.New("not used")
+}
+func (f *fakeRegistry) GetAIProvider(name string) (outbound.AIProvider, error) {
+	return nil, errors.New("not used")
+}
+
+func TestQuickScanSkill_Aggregates(t *testing.T) {
+	reg := &fakeRegistry{
+		inv: map[string]outbound.InventoryProvider{
+			"aws": &fakeInv{summary: &inventory.Summary{ProviderName: "aws", Total: 10, CountByType: map[string]int{"EC2": 7, "S3": 3}}},
+			"gcp": &fakeInv{summary: &inventory.Summary{ProviderName: "gcp", Total: 5, CountByType: map[string]int{"computeEngine": 2, "cloudStorage": 3}}},
+		},
+	}
+	skill := NewQuickScanSkill(reg)
+	out, err := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws", "gcp"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["grand_total"].(int) != 15 {
+		t.Fatalf("expected grand_total=15, got %+v", m["grand_total"])
+	}
+	if m["note"] == "" {
+		t.Fatal("expected disclaimer note about resource-count proxy")
+	}
+}
+
+func TestQuickScanSkill_ScanError(t *testing.T) {
+	reg := &fakeRegistry{
+		inv: map[string]outbound.InventoryProvider{
+			"aws": &fakeInv{err: errors.New("permission denied")},
+		},
+	}
+	skill := NewQuickScanSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	report := out.(map[string]any)["providers"].([]map[string]any)
+	if report[0]["ok"] != false {
+		t.Fatalf("expected ok=false on scan error, got %+v", report[0])
+	}
+}

--- a/internal/application/doctor/auth_skill.go
+++ b/internal/application/doctor/auth_skill.go
@@ -1,0 +1,99 @@
+// File: internal/application/doctor/auth_skill.go
+// Purpose: Implements the doctor.auth skill — checks authentication health across all configured providers.
+
+package doctor
+
+import (
+	"context"
+
+	"multix/internal/domain/skills"
+	"multix/internal/ports/outbound"
+)
+
+// AuthSkill validates authentication against one or many providers and returns
+// structured findings (provider, ok, account, principal, error).
+type AuthSkill struct {
+	providers outbound.ProviderRegistry
+}
+
+// NewAuthSkill creates a new AuthSkill.
+func NewAuthSkill(pr outbound.ProviderRegistry) skills.Skill {
+	return &AuthSkill{providers: pr}
+}
+
+func (s *AuthSkill) Name() string { return "doctor.auth" }
+func (s *AuthSkill) Description() string {
+	return "Validates authentication context for one or more cloud providers and reports per-provider health."
+}
+func (s *AuthSkill) InputSchema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"providers": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Optional list of providers (aws, gcp, oci). If omitted, checks all three.",
+			},
+		},
+	}
+}
+
+func (s *AuthSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	requested := extractProviders(input)
+	findings := make([]map[string]any, 0, len(requested))
+	healthy := 0
+
+	for _, name := range requested {
+		f := map[string]any{"provider": name}
+		p, err := s.providers.GetCloudAuthProvider(name)
+		if err != nil {
+			f["ok"] = false
+			f["error"] = err.Error()
+			findings = append(findings, f)
+			continue
+		}
+		result, err := p.Validate(ctx)
+		if err != nil {
+			f["ok"] = false
+			f["error"] = err.Error()
+			findings = append(findings, f)
+			continue
+		}
+		f["ok"] = result.Valid
+		f["account"] = result.AccountID
+		f["principal"] = result.Principal
+		f["message"] = result.Message
+		if result.Valid {
+			healthy++
+		}
+		findings = append(findings, f)
+	}
+
+	return map[string]any{
+		"checked":  len(requested),
+		"healthy":  healthy,
+		"findings": findings,
+	}, nil
+}
+
+func extractProviders(input map[string]any) []string {
+	defaults := []string{"aws", "gcp", "oci"}
+	raw, ok := input["providers"]
+	if !ok || raw == nil {
+		return defaults
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return defaults
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return defaults
+	}
+	return out
+}

--- a/internal/application/doctor/auth_skill_test.go
+++ b/internal/application/doctor/auth_skill_test.go
@@ -1,0 +1,107 @@
+// File: internal/application/doctor/auth_skill_test.go
+package doctor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/auth"
+	"multix/internal/ports/outbound"
+)
+
+type fakeAuthProvider struct {
+	id     string
+	result *auth.ValidationResult
+	err    error
+}
+
+func (f *fakeAuthProvider) ID() string { return f.id }
+func (f *fakeAuthProvider) Login(ctx context.Context, c auth.Credentials) (*auth.Session, error) {
+	return nil, nil
+}
+func (f *fakeAuthProvider) Whoami(ctx context.Context) (*auth.Identity, error) {
+	return &auth.Identity{Provider: f.id}, nil
+}
+func (f *fakeAuthProvider) Validate(ctx context.Context) (*auth.ValidationResult, error) {
+	return f.result, f.err
+}
+
+type fakeRegistry struct {
+	auth     map[string]*fakeAuthProvider
+	authErr  map[string]error
+	k8s      map[string]outbound.K8sProvider
+	k8sErr   map[string]error
+}
+
+func (f *fakeRegistry) GetCloudAuthProvider(name string) (outbound.AuthProvider, error) {
+	if err, ok := f.authErr[name]; ok {
+		return nil, err
+	}
+	if p, ok := f.auth[name]; ok {
+		return p, nil
+	}
+	return nil, errors.New("unknown provider: " + name)
+}
+func (f *fakeRegistry) GetCloudInventoryProvider(name string) (outbound.InventoryProvider, error) {
+	return nil, errors.New("not used in this test")
+}
+func (f *fakeRegistry) GetKubernetesProvider(name string) (outbound.K8sProvider, error) {
+	if err, ok := f.k8sErr[name]; ok {
+		return nil, err
+	}
+	if p, ok := f.k8s[name]; ok {
+		return p, nil
+	}
+	return nil, errors.New("unknown k8s provider: " + name)
+}
+func (f *fakeRegistry) GetAIProvider(name string) (outbound.AIProvider, error) {
+	return nil, errors.New("not used in this test")
+}
+
+func TestAuthSkill_Defaults(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]*fakeAuthProvider{
+		"aws": {id: "aws", result: &auth.ValidationResult{Provider: "aws", Valid: true, AccountID: "123", Principal: "arn:..."}},
+		"gcp": {id: "gcp", result: &auth.ValidationResult{Provider: "gcp", Valid: true, AccountID: "demo-project"}},
+		"oci": {id: "oci", err: errors.New("not configured")},
+	}}
+	skill := NewAuthSkill(reg)
+	out, err := skill.Execute(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["checked"].(int) != 3 || m["healthy"].(int) != 2 {
+		t.Fatalf("unexpected counts: %+v", m)
+	}
+	findings := m["findings"].([]map[string]any)
+	if len(findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(findings))
+	}
+	// Last (oci) should be ok=false with the error
+	last := findings[2]
+	if last["provider"] != "oci" || last["ok"] != false || last["error"] == "" {
+		t.Fatalf("unexpected oci finding: %+v", last)
+	}
+}
+
+func TestAuthSkill_FilteredProviders(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]*fakeAuthProvider{
+		"aws": {id: "aws", result: &auth.ValidationResult{Valid: true}},
+	}}
+	skill := NewAuthSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	if out.(map[string]any)["checked"].(int) != 1 {
+		t.Fatalf("expected single provider check, got %+v", out)
+	}
+}
+
+func TestAuthSkill_ProviderUnregistered(t *testing.T) {
+	reg := &fakeRegistry{authErr: map[string]error{"aws": errors.New("not registered")}}
+	skill := NewAuthSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	findings := out.(map[string]any)["findings"].([]map[string]any)
+	if findings[0]["ok"] != false || findings[0]["error"] != "not registered" {
+		t.Fatalf("expected not-registered error, got %+v", findings[0])
+	}
+}

--- a/internal/application/doctor/k8s_skill.go
+++ b/internal/application/doctor/k8s_skill.go
@@ -1,0 +1,105 @@
+// File: internal/application/doctor/k8s_skill.go
+// Purpose: Implements the doctor.k8s skill — reports cluster health across providers.
+
+package doctor
+
+import (
+	"context"
+	"strings"
+
+	"multix/internal/domain/skills"
+	"multix/internal/ports/outbound"
+)
+
+// K8sHealthSkill lists clusters per provider and classifies each as healthy/unhealthy
+// based on lifecycle state. It does not connect to the cluster control plane — that
+// would require kubeconfig sync and is deferred to a deeper diagnostic skill.
+type K8sHealthSkill struct {
+	providers outbound.ProviderRegistry
+}
+
+// NewK8sHealthSkill creates a new K8sHealthSkill.
+func NewK8sHealthSkill(pr outbound.ProviderRegistry) skills.Skill {
+	return &K8sHealthSkill{providers: pr}
+}
+
+func (s *K8sHealthSkill) Name() string { return "doctor.k8s" }
+func (s *K8sHealthSkill) Description() string {
+	return "Lists managed Kubernetes clusters per provider and classifies them as healthy or degraded based on lifecycle state."
+}
+func (s *K8sHealthSkill) InputSchema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"providers": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"type": "string"},
+			},
+		},
+	}
+}
+
+func (s *K8sHealthSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	requested := extractProviders(input)
+	report := make([]map[string]any, 0, len(requested))
+	totalClusters, totalHealthy := 0, 0
+
+	for _, name := range requested {
+		entry := map[string]any{"provider": name}
+		p, err := s.providers.GetKubernetesProvider(name)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		clusters, err := p.ListClusters(ctx)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		clusterRows := make([]map[string]any, 0, len(clusters))
+		healthy := 0
+		for _, c := range clusters {
+			h := isHealthyClusterStatus(c.Status)
+			if h {
+				healthy++
+			}
+			clusterRows = append(clusterRows, map[string]any{
+				"name":       c.Name,
+				"region":     c.Region,
+				"version":    c.Version,
+				"status":     c.Status,
+				"healthy":    h,
+				"node_count": c.NodeCount,
+			})
+		}
+		totalClusters += len(clusters)
+		totalHealthy += healthy
+		entry["ok"] = true
+		entry["count"] = len(clusters)
+		entry["healthy"] = healthy
+		entry["clusters"] = clusterRows
+		report = append(report, entry)
+	}
+
+	return map[string]any{
+		"checked_providers": len(requested),
+		"total_clusters":    totalClusters,
+		"total_healthy":     totalHealthy,
+		"providers":         report,
+	}, nil
+}
+
+// isHealthyClusterStatus maps provider-specific cluster statuses to a boolean.
+// AWS EKS: ACTIVE; GCP GKE: RUNNING; OCI OKE: ACTIVE.
+func isHealthyClusterStatus(s string) bool {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "ACTIVE", "RUNNING":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/application/doctor/k8s_skill_test.go
+++ b/internal/application/doctor/k8s_skill_test.go
@@ -1,0 +1,76 @@
+// File: internal/application/doctor/k8s_skill_test.go
+package doctor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/k8s"
+	"multix/internal/ports/outbound"
+)
+
+type fakeK8s struct {
+	id       string
+	clusters []*k8s.Cluster
+	err      error
+}
+
+func (f *fakeK8s) ID() string { return f.id }
+func (f *fakeK8s) ListClusters(ctx context.Context) ([]*k8s.Cluster, error) {
+	return f.clusters, f.err
+}
+func (f *fakeK8s) SyncContext(ctx context.Context, name, region string) error { return nil }
+
+func TestK8sHealthSkill_HappyPath(t *testing.T) {
+	reg := &fakeRegistry{
+		k8s: map[string]outbound.K8sProvider{
+			"aws": &fakeK8s{id: "aws", clusters: []*k8s.Cluster{
+				{Name: "prod", Status: "ACTIVE", Version: "1.30"},
+				{Name: "dev", Status: "CREATING", Version: "1.30"},
+			}},
+			"gcp": &fakeK8s{id: "gcp", clusters: []*k8s.Cluster{{Name: "g1", Status: "RUNNING"}}},
+			"oci": &fakeK8s{id: "oci", clusters: nil},
+		},
+	}
+	skill := NewK8sHealthSkill(reg)
+	out, err := skill.Execute(context.Background(), map[string]any{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	m := out.(map[string]any)
+	if m["total_clusters"].(int) != 3 || m["total_healthy"].(int) != 2 {
+		t.Fatalf("unexpected aggregates: %+v", m)
+	}
+}
+
+func TestK8sHealthSkill_ProviderError(t *testing.T) {
+	reg := &fakeRegistry{
+		k8s: map[string]outbound.K8sProvider{
+			"aws": &fakeK8s{err: errors.New("api unreachable")},
+		},
+	}
+	skill := NewK8sHealthSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	report := out.(map[string]any)["providers"].([]map[string]any)
+	if report[0]["ok"] != false || report[0]["error"] == "" {
+		t.Fatalf("expected error-flagged provider entry, got %+v", report[0])
+	}
+}
+
+func TestIsHealthyClusterStatus(t *testing.T) {
+	cases := map[string]bool{
+		"ACTIVE":  true,
+		"RUNNING": true,
+		"running": true,
+		" Active": true,
+		"CREATING": false,
+		"DELETING": false,
+		"":         false,
+	}
+	for input, want := range cases {
+		if got := isHealthyClusterStatus(input); got != want {
+			t.Errorf("isHealthyClusterStatus(%q) = %v; want %v", input, got, want)
+		}
+	}
+}

--- a/internal/application/landingzone/audit_skill.go
+++ b/internal/application/landingzone/audit_skill.go
@@ -1,0 +1,121 @@
+// File: internal/application/landingzone/audit_skill.go
+// Purpose: Implements the landingzone.audit skill — baseline checks for multi-account/multi-region landing zone health.
+
+package landingzone
+
+import (
+	"context"
+
+	"multix/internal/domain/skills"
+	"multix/internal/ports/outbound"
+)
+
+// AuditSkill performs first-pass landing zone validation by combining auth identity
+// (account/tenancy/project ID) with inventory presence (multi-region resource spread).
+// Deeper org-level checks (AWS Organizations, GCP Folders, OCI compartment trees) are
+// scoped to follow-up issues; this skill establishes the contract and surface.
+type AuditSkill struct {
+	providers outbound.ProviderRegistry
+}
+
+// NewAuditSkill creates a new AuditSkill.
+func NewAuditSkill(pr outbound.ProviderRegistry) skills.Skill {
+	return &AuditSkill{providers: pr}
+}
+
+func (s *AuditSkill) Name() string { return "landingzone.audit" }
+func (s *AuditSkill) Description() string {
+	return "Baseline landing zone audit: confirms identity context and reports multi-region resource spread per provider. Deeper org/folder/compartment trees are deferred to follow-up checks."
+}
+func (s *AuditSkill) InputSchema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"providers": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		},
+	}
+}
+
+func (s *AuditSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	requested := extractProviders(input)
+	report := make([]map[string]any, 0, len(requested))
+	for _, name := range requested {
+		entry := map[string]any{"provider": name}
+
+		auth, err := s.providers.GetCloudAuthProvider(name)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		validation, err := auth.Validate(ctx)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		entry["account"] = validation.AccountID
+		entry["principal"] = validation.Principal
+
+		// Inventory spread: count distinct regions across resources.
+		inv, err := s.providers.GetCloudInventoryProvider(name)
+		if err != nil {
+			entry["ok"] = false
+			entry["error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		resources, err := inv.List(ctx, "")
+		if err != nil {
+			entry["ok"] = true
+			entry["inventory_error"] = err.Error()
+			report = append(report, entry)
+			continue
+		}
+		regions := map[string]struct{}{}
+		for _, r := range resources {
+			if r.Region != "" {
+				regions[r.Region] = struct{}{}
+			}
+		}
+		entry["ok"] = true
+		entry["resource_count"] = len(resources)
+		entry["distinct_regions"] = len(regions)
+		entry["multi_region"] = len(regions) > 1
+		entry["regions"] = mapKeys(regions)
+		report = append(report, entry)
+	}
+	return map[string]any{"providers": report}, nil
+}
+
+func extractProviders(input map[string]any) []string {
+	defaults := []string{"aws", "gcp", "oci"}
+	raw, ok := input["providers"]
+	if !ok || raw == nil {
+		return defaults
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return defaults
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return defaults
+	}
+	return out
+}
+
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/application/landingzone/audit_skill_test.go
+++ b/internal/application/landingzone/audit_skill_test.go
@@ -1,0 +1,100 @@
+// File: internal/application/landingzone/audit_skill_test.go
+package landingzone
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/auth"
+	"multix/internal/domain/inventory"
+	"multix/internal/ports/outbound"
+)
+
+type fakeAuth struct {
+	result *auth.ValidationResult
+	err    error
+}
+
+func (f *fakeAuth) ID() string                                                 { return "" }
+func (f *fakeAuth) Login(ctx context.Context, c auth.Credentials) (*auth.Session, error) {
+	return nil, nil
+}
+func (f *fakeAuth) Whoami(ctx context.Context) (*auth.Identity, error) { return nil, nil }
+func (f *fakeAuth) Validate(ctx context.Context) (*auth.ValidationResult, error) {
+	return f.result, f.err
+}
+
+type fakeInventory struct {
+	resources []*inventory.Resource
+	err       error
+}
+
+func (f *fakeInventory) ID() string { return "" }
+func (f *fakeInventory) List(ctx context.Context, t string) ([]*inventory.Resource, error) {
+	return f.resources, f.err
+}
+func (f *fakeInventory) Scan(ctx context.Context) (*inventory.Summary, error) {
+	return nil, nil
+}
+
+type fakeRegistry struct {
+	auth map[string]outbound.AuthProvider
+	inv  map[string]outbound.InventoryProvider
+}
+
+func (f *fakeRegistry) GetCloudAuthProvider(name string) (outbound.AuthProvider, error) {
+	if p, ok := f.auth[name]; ok {
+		return p, nil
+	}
+	return nil, errors.New("unknown")
+}
+func (f *fakeRegistry) GetCloudInventoryProvider(name string) (outbound.InventoryProvider, error) {
+	if p, ok := f.inv[name]; ok {
+		return p, nil
+	}
+	return nil, errors.New("unknown")
+}
+func (f *fakeRegistry) GetKubernetesProvider(name string) (outbound.K8sProvider, error) {
+	return nil, errors.New("not used")
+}
+func (f *fakeRegistry) GetAIProvider(name string) (outbound.AIProvider, error) {
+	return nil, errors.New("not used")
+}
+
+func TestAuditSkill_HappyPath(t *testing.T) {
+	reg := &fakeRegistry{
+		auth: map[string]outbound.AuthProvider{
+			"aws": &fakeAuth{result: &auth.ValidationResult{AccountID: "123", Principal: "arn:..."}},
+		},
+		inv: map[string]outbound.InventoryProvider{
+			"aws": &fakeInventory{resources: []*inventory.Resource{
+				{Region: "us-east-1"}, {Region: "us-east-1"}, {Region: "eu-west-1"},
+			}},
+		},
+	}
+	skill := NewAuditSkill(reg)
+	out, err := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	report := out.(map[string]any)["providers"].([]map[string]any)
+	entry := report[0]
+	if entry["account"] != "123" || entry["resource_count"].(int) != 3 || entry["distinct_regions"].(int) != 2 || entry["multi_region"] != true {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+}
+
+func TestAuditSkill_AuthError(t *testing.T) {
+	reg := &fakeRegistry{
+		auth: map[string]outbound.AuthProvider{
+			"aws": &fakeAuth{err: errors.New("expired")},
+		},
+	}
+	skill := NewAuditSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	entry := out.(map[string]any)["providers"].([]map[string]any)[0]
+	if entry["ok"] != false {
+		t.Fatalf("expected ok=false on auth error, got %+v", entry)
+	}
+}

--- a/internal/application/security/identity_posture_skill.go
+++ b/internal/application/security/identity_posture_skill.go
@@ -1,0 +1,121 @@
+// File: internal/application/security/identity_posture_skill.go
+// Purpose: Implements the security.identity-posture skill — flags risky principal types in active auth context.
+
+package security
+
+import (
+	"context"
+	"strings"
+
+	"multix/internal/domain/skills"
+	"multix/internal/ports/outbound"
+)
+
+// IdentityPostureSkill validates the active identity per provider and emits
+// posture findings (severity, category, message). v1 focuses on signals
+// derivable from auth.Validate output: principal type, root/owner usage,
+// missing tenancy/project context. Full IAM enumeration (users, roles,
+// policies) is scoped to a follow-up issue.
+type IdentityPostureSkill struct {
+	providers outbound.ProviderRegistry
+}
+
+// NewIdentityPostureSkill creates a new IdentityPostureSkill.
+func NewIdentityPostureSkill(pr outbound.ProviderRegistry) skills.Skill {
+	return &IdentityPostureSkill{providers: pr}
+}
+
+func (s *IdentityPostureSkill) Name() string { return "security.identity_posture" }
+func (s *IdentityPostureSkill) Description() string {
+	return "Reports identity posture findings (severity-tagged) for the active auth context across providers. v1 surfaces principal-type risks; deeper IAM enumeration is a follow-up."
+}
+func (s *IdentityPostureSkill) InputSchema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"providers": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		},
+	}
+}
+
+func (s *IdentityPostureSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	requested := extractProviders(input)
+	allFindings := make([]map[string]any, 0)
+
+	for _, name := range requested {
+		p, err := s.providers.GetCloudAuthProvider(name)
+		if err != nil {
+			allFindings = append(allFindings, finding(name, "high", "auth_resolution",
+				"Provider not registered or unsupported", err.Error()))
+			continue
+		}
+		identity, err := p.Whoami(ctx)
+		if err != nil {
+			allFindings = append(allFindings, finding(name, "high", "whoami",
+				"Could not resolve active identity", err.Error()))
+			continue
+		}
+
+		principal := strings.ToLower(identity.Principal)
+		switch {
+		case strings.Contains(principal, ":root"):
+			allFindings = append(allFindings, finding(name, "critical", "root_usage",
+				"AWS root user is active — never use root for day-to-day operations", identity.Principal))
+		case identity.PrincipalType == "user" && name == "aws":
+			allFindings = append(allFindings, finding(name, "medium", "long_lived_user",
+				"AWS access via IAM user; prefer IAM Identity Center / SSO with assumed roles", identity.Principal))
+		case identity.PrincipalType == "instance_principal":
+			allFindings = append(allFindings, finding(name, "info", "instance_principal",
+				"Authenticated via instance principal", identity.Principal))
+		case identity.PrincipalType == "" || identity.PrincipalType == "unknown":
+			allFindings = append(allFindings, finding(name, "low", "unknown_principal_type",
+				"Active principal type could not be determined", identity.Principal))
+		default:
+			allFindings = append(allFindings, finding(name, "info", "active_principal",
+				"Active principal type: "+identity.PrincipalType, identity.Principal))
+		}
+	}
+
+	severityCounts := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
+	for _, f := range allFindings {
+		sev, _ := f["severity"].(string)
+		severityCounts[sev]++
+	}
+
+	return map[string]any{
+		"findings":        allFindings,
+		"severity_counts": severityCounts,
+	}, nil
+}
+
+func finding(provider, severity, category, message, evidence string) map[string]any {
+	return map[string]any{
+		"provider": provider,
+		"severity": severity,
+		"category": category,
+		"message":  message,
+		"evidence": evidence,
+	}
+}
+
+func extractProviders(input map[string]any) []string {
+	defaults := []string{"aws", "gcp", "oci"}
+	raw, ok := input["providers"]
+	if !ok || raw == nil {
+		return defaults
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return defaults
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return defaults
+	}
+	return out
+}

--- a/internal/application/security/identity_posture_skill_test.go
+++ b/internal/application/security/identity_posture_skill_test.go
@@ -1,0 +1,120 @@
+// File: internal/application/security/identity_posture_skill_test.go
+package security
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"multix/internal/domain/auth"
+	"multix/internal/ports/outbound"
+)
+
+type fakeAuth struct {
+	identity *auth.Identity
+	err      error
+}
+
+func (f *fakeAuth) ID() string                                                 { return "" }
+func (f *fakeAuth) Login(ctx context.Context, c auth.Credentials) (*auth.Session, error) {
+	return nil, nil
+}
+func (f *fakeAuth) Whoami(ctx context.Context) (*auth.Identity, error) {
+	return f.identity, f.err
+}
+func (f *fakeAuth) Validate(ctx context.Context) (*auth.ValidationResult, error) {
+	return nil, nil
+}
+
+type fakeRegistry struct {
+	auth    map[string]outbound.AuthProvider
+	authErr map[string]error
+}
+
+func (f *fakeRegistry) GetCloudAuthProvider(name string) (outbound.AuthProvider, error) {
+	if err, ok := f.authErr[name]; ok {
+		return nil, err
+	}
+	if p, ok := f.auth[name]; ok {
+		return p, nil
+	}
+	return nil, errors.New("unknown")
+}
+func (f *fakeRegistry) GetCloudInventoryProvider(name string) (outbound.InventoryProvider, error) {
+	return nil, errors.New("not used")
+}
+func (f *fakeRegistry) GetKubernetesProvider(name string) (outbound.K8sProvider, error) {
+	return nil, errors.New("not used")
+}
+func (f *fakeRegistry) GetAIProvider(name string) (outbound.AIProvider, error) {
+	return nil, errors.New("not used")
+}
+
+func TestIdentityPostureSkill_RootDetected(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]outbound.AuthProvider{
+		"aws": &fakeAuth{identity: &auth.Identity{
+			Provider:      "aws",
+			Principal:     "arn:aws:iam::123:root",
+			PrincipalType: "user",
+		}},
+	}}
+	skill := NewIdentityPostureSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	findings := out.(map[string]any)["findings"].([]map[string]any)
+	if findings[0]["severity"] != "critical" || findings[0]["category"] != "root_usage" {
+		t.Fatalf("expected critical root_usage, got %+v", findings[0])
+	}
+}
+
+func TestIdentityPostureSkill_LongLivedAWSUser(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]outbound.AuthProvider{
+		"aws": &fakeAuth{identity: &auth.Identity{
+			Provider:      "aws",
+			Principal:     "arn:aws:iam::123:user/marcio",
+			PrincipalType: "user",
+		}},
+	}}
+	skill := NewIdentityPostureSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	findings := out.(map[string]any)["findings"].([]map[string]any)
+	if findings[0]["severity"] != "medium" || findings[0]["category"] != "long_lived_user" {
+		t.Fatalf("expected medium long_lived_user, got %+v", findings[0])
+	}
+}
+
+func TestIdentityPostureSkill_InfoForRole(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]outbound.AuthProvider{
+		"aws": &fakeAuth{identity: &auth.Identity{Provider: "aws", Principal: "arn:aws:sts::123:assumed-role/Admin/sess", PrincipalType: "role"}},
+	}}
+	skill := NewIdentityPostureSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	findings := out.(map[string]any)["findings"].([]map[string]any)
+	if findings[0]["severity"] != "info" {
+		t.Fatalf("expected info, got %+v", findings[0])
+	}
+}
+
+func TestIdentityPostureSkill_WhoamiError(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]outbound.AuthProvider{
+		"aws": &fakeAuth{err: errors.New("expired token")},
+	}}
+	skill := NewIdentityPostureSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	findings := out.(map[string]any)["findings"].([]map[string]any)
+	if findings[0]["severity"] != "high" || findings[0]["category"] != "whoami" {
+		t.Fatalf("expected high whoami finding, got %+v", findings[0])
+	}
+}
+
+func TestIdentityPostureSkill_SeverityCounts(t *testing.T) {
+	reg := &fakeRegistry{auth: map[string]outbound.AuthProvider{
+		"aws": &fakeAuth{identity: &auth.Identity{Principal: "arn:aws:iam::123:root", PrincipalType: "user"}},
+		"gcp": &fakeAuth{identity: &auth.Identity{Provider: "gcp", PrincipalType: "service_account"}},
+	}}
+	skill := NewIdentityPostureSkill(reg)
+	out, _ := skill.Execute(context.Background(), map[string]any{"providers": []any{"aws", "gcp"}})
+	counts := out.(map[string]any)["severity_counts"].(map[string]int)
+	if counts["critical"] != 1 || counts["info"] != 1 {
+		t.Fatalf("unexpected counts: %+v", counts)
+	}
+}

--- a/internal/bootstrap/skills.go
+++ b/internal/bootstrap/skills.go
@@ -10,9 +10,12 @@ package bootstrap
 import (
 	"multix/internal/application/ai"
 	"multix/internal/application/auth"
+	"multix/internal/application/cost"
 	"multix/internal/application/doctor"
 	"multix/internal/application/inventory"
 	"multix/internal/application/k8s"
+	"multix/internal/application/landingzone"
+	"multix/internal/application/security"
 	"multix/internal/domain/skills"
 	"multix/internal/ports/outbound"
 )
@@ -24,6 +27,17 @@ func BuildSkillRegistry(providers outbound.ProviderRegistry) *skills.Registry {
 
 	// Platform diagnostics.
 	skillRegistry.Register(doctor.NewCheckEnvSkill())
+	skillRegistry.Register(doctor.NewAuthSkill(providers))
+	skillRegistry.Register(doctor.NewK8sHealthSkill(providers))
+
+	// Landing zone & governance.
+	skillRegistry.Register(landingzone.NewAuditSkill(providers))
+
+	// Security posture.
+	skillRegistry.Register(security.NewIdentityPostureSkill(providers))
+
+	// Cost (quick proxy; full FOCUS report is #46).
+	skillRegistry.Register(cost.NewQuickScanSkill(providers))
 
 	// Authentication and identity.
 	skillRegistry.Register(auth.NewLoginSkill(providers))


### PR DESCRIPTION
## Summary
Five new skills exposing a multi-cloud audit surface, all built on top of the v0.5 inventory and v0.6 list_clusters work.

| Issue | Skill name                  | What it does (v1)                                                      |
|-------|-----------------------------|------------------------------------------------------------------------|
| #14   | \`doctor.auth\`               | Per-provider \`Validate()\`; healthy count                                |
| #15   | \`doctor.k8s\`                | Per-provider \`ListClusters\` + lifecycle-state health classification     |
| #16   | \`landingzone.audit\`         | Identity context + multi-region resource spread baseline                |
| #17   | \`security.identity_posture\` | Severity-tagged findings from \`Whoami\` (root usage critical, etc.)      |
| #18   | \`cost.quick_scan\`           | Inventory.Summary aggregation as a *resource-count proxy*               |

All five accept an optional \`providers[]\` filter and default to all three clouds. Each finding/entry is structured (severity, category, message, evidence) so the agent can reason over the output.

## Honest scope
- #14 / #15 are fully implemented on existing providers — no new SDK surface.
- #16 / #17 / #18 are useful first-pass implementations using auth + inventory + k8s data already collected. Deeper provider-specific calls (AWS Organizations, IAM enumeration, Cost Explorer / FOCUS billing) are scoped to follow-ups (#46 cost.focus_report, future identity-deep-audit).
- The \`cost.quick_scan\` description explicitly tells the agent it is a count proxy and points to #46 for real billing.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./... -count=1\` — all green
- [x] \`make test-race\` — all green
- [x] 13 new unit tests across doctor / landingzone / security / cost packages, using local fake ProviderRegistry
- [ ] Live smoke (manual, requires creds): exercise each skill via \`POST /execute\` against \`multix serve\`

## Notes
This concludes the Claude frente per the tri-agent plan: v0.5 (#50), v0.6 (#51), v0.7 (this PR). Branched from v0.6 since dependencies are cumulative; rebases cleanly once #50/#51 land.

---

Closes #14
Closes #15
Closes #16
Closes #17
Closes #18