### PR TITLE
test(inventory): add cloud inventory stubs

### DIFF
--- a/internal/adapters/outbound/cloud/stub/inventory.go
+++ b/internal/adapters/outbound/cloud/stub/inventory.go
@@ -1,0 +1,180 @@
+// File: internal/adapters/outbound/cloud/stub/inventory.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 02/05/2026
+// Updated: 02/05/2026
+// Purpose: Provides deterministic cloud inventory stubs for local tests.
+
+package stub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"multix/internal/domain/inventory"
+)
+
+var errUnsupportedProvider = errors.New("unsupported inventory stub provider")
+
+var fixedInventoryTime = time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+
+// InventoryProvider serves deterministic cloud inventory responses for tests.
+type InventoryProvider struct {
+	provider  string
+	resources []*inventory.Resource
+}
+
+// NewInventoryProvider creates an inventory provider backed by local cloud fixtures.
+func NewInventoryProvider(provider string) (*InventoryProvider, error) {
+	key := normalizeProvider(provider)
+	resources, ok := inventoryFixtures()[key]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", errUnsupportedProvider, provider)
+	}
+
+	return &InventoryProvider{
+		provider:  key,
+		resources: cloneResources(resources),
+	}, nil
+}
+
+// MustInventoryProvider creates a fixture-backed provider and panics on invalid test setup.
+func MustInventoryProvider(provider string) *InventoryProvider {
+	p, err := NewInventoryProvider(provider)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+// SupportedInventoryProviders returns the cloud names backed by local fixtures.
+func SupportedInventoryProviders() []string {
+	providers := make([]string, 0, len(inventoryFixtures()))
+	for provider := range inventoryFixtures() {
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers)
+	return providers
+}
+
+// ID returns the provider identifier.
+func (p *InventoryProvider) ID() string {
+	return p.provider
+}
+
+// List returns fixture resources filtered by service/resource type.
+func (p *InventoryProvider) List(ctx context.Context, resourceType string) ([]*inventory.Resource, error) {
+	filter := normalizeProvider(resourceType)
+	if filter == "" {
+		return cloneResources(p.resources), nil
+	}
+
+	var resources []*inventory.Resource
+	for _, resource := range p.resources {
+		if matchesResourceType(resource.Type, filter) {
+			resources = append(resources, cloneResource(resource))
+		}
+	}
+
+	return resources, nil
+}
+
+// Scan summarizes all fixture resources for the provider.
+func (p *InventoryProvider) Scan(ctx context.Context) (*inventory.Summary, error) {
+	counts := make(map[string]int)
+	for _, resource := range p.resources {
+		counts[resource.Type]++
+	}
+
+	return &inventory.Summary{
+		ProviderName: p.provider,
+		Total:        len(p.resources),
+		CountByType:  counts,
+	}, nil
+}
+
+func inventoryFixtures() map[string][]*inventory.Resource {
+	return map[string][]*inventory.Resource{
+		"aws": {
+			newFixtureResource("i-0abc123", "123456789012", "us-east-1", "EC2", "prod-web-server", "RUNNING"),
+			newFixtureResource("bucket-prod-logs", "123456789012", "us-east-1", "S3", "prod-logs", "ACTIVE"),
+		},
+		"gcp": {
+			newFixtureResource("gce-prod-api", "demo-project", "us-central1", "computeEngine", "gce-prod-api", "RUNNING"),
+			newFixtureResource("gcs-backup-vault", "demo-project", "us-central1", "cloudStorage", "gcs-backup-vault", "ACTIVE"),
+		},
+		"oci": {
+			newFixtureResource("ocid1.instance.oc1..stub", "ocid1.tenancy.oc1..stub", "us-ashburn-1", "Compute", "prod-web-server-oci", "RUNNING"),
+			newFixtureResource("ocid1.bucket.oc1..stub", "ocid1.tenancy.oc1..stub", "us-ashburn-1", "Bucket", "prod-object-archive", "ACTIVE"),
+		},
+	}
+}
+
+func newFixtureResource(id, accountID, region, resourceType, name, status string) *inventory.Resource {
+	return &inventory.Resource{
+		ID:        id,
+		AccountID: accountID,
+		Region:    region,
+		Type:      resourceType,
+		Name:      name,
+		Status:    status,
+		Tags: map[string]string{
+			"source": "stub",
+		},
+		CreatedAt: fixedInventoryTime,
+	}
+}
+
+func matchesResourceType(resourceType, filter string) bool {
+	normalizedType := normalizeProvider(resourceType)
+	if normalizedType == filter {
+		return true
+	}
+
+	for _, alias := range resourceTypeAliases(filter) {
+		if normalizedType == alias {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceTypeAliases(filter string) []string {
+	switch filter {
+	case "compute":
+		return []string{"ec2", "computeengine"}
+	case "storage":
+		return []string{"s3", "cloudstorage", "bucket"}
+	default:
+		return nil
+	}
+}
+
+func normalizeProvider(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func cloneResources(resources []*inventory.Resource) []*inventory.Resource {
+	clones := make([]*inventory.Resource, 0, len(resources))
+	for _, resource := range resources {
+		clones = append(clones, cloneResource(resource))
+	}
+	return clones
+}
+
+func cloneResource(resource *inventory.Resource) *inventory.Resource {
+	if resource == nil {
+		return nil
+	}
+
+	clone := *resource
+	clone.Tags = make(map[string]string, len(resource.Tags))
+	for key, value := range resource.Tags {
+		clone.Tags[key] = value
+	}
+	return &clone
+}

--- a/internal/adapters/outbound/cloud/stub/inventory_test.go
+++ b/internal/adapters/outbound/cloud/stub/inventory_test.go
@@ -1,0 +1,88 @@
+// File: internal/adapters/outbound/cloud/stub/inventory_test.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 02/05/2026
+// Updated: 02/05/2026
+// Purpose: Verifies deterministic inventory stubs for local cloud tests.
+
+package stub
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInventoryProviderFixtures(t *testing.T) {
+	tests := []struct {
+		provider     string
+		computeType  string
+		storageType  string
+		expectedName string
+	}{
+		{provider: "aws", computeType: "EC2", storageType: "S3", expectedName: "prod-web-server"},
+		{provider: "gcp", computeType: "computeEngine", storageType: "cloudStorage", expectedName: "gce-prod-api"},
+		{provider: "oci", computeType: "Compute", storageType: "Bucket", expectedName: "prod-web-server-oci"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			provider := MustInventoryProvider(tt.provider)
+
+			if provider.ID() != tt.provider {
+				t.Fatalf("expected provider ID %q, got %q", tt.provider, provider.ID())
+			}
+
+			compute, err := provider.List(context.Background(), "compute")
+			if err != nil {
+				t.Fatalf("unexpected compute list error: %v", err)
+			}
+			if len(compute) != 1 || compute[0].Type != tt.computeType || compute[0].Name != tt.expectedName {
+				t.Fatalf("unexpected compute resources: %+v", compute)
+			}
+
+			storage, err := provider.List(context.Background(), "storage")
+			if err != nil {
+				t.Fatalf("unexpected storage list error: %v", err)
+			}
+			if len(storage) != 1 || storage[0].Type != tt.storageType {
+				t.Fatalf("unexpected storage resources: %+v", storage)
+			}
+
+			summary, err := provider.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected scan error: %v", err)
+			}
+			if summary.ProviderName != tt.provider || summary.Total != 2 {
+				t.Fatalf("unexpected summary: %+v", summary)
+			}
+			if summary.CountByType[tt.computeType] != 1 || summary.CountByType[tt.storageType] != 1 {
+				t.Fatalf("unexpected summary counts: %+v", summary.CountByType)
+			}
+		})
+	}
+}
+
+func TestInventoryProviderReturnsClonedResources(t *testing.T) {
+	provider := MustInventoryProvider("aws")
+
+	resources, err := provider.List(context.Background(), "compute")
+	if err != nil {
+		t.Fatalf("unexpected list error: %v", err)
+	}
+	resources[0].Name = "mutated"
+	resources[0].Tags["source"] = "mutated"
+
+	nextResources, err := provider.List(context.Background(), "compute")
+	if err != nil {
+		t.Fatalf("unexpected second list error: %v", err)
+	}
+	if nextResources[0].Name == "mutated" || nextResources[0].Tags["source"] == "mutated" {
+		t.Fatalf("expected cloned fixture resources, got %+v", nextResources[0])
+	}
+}
+
+func TestNewInventoryProviderRejectsUnsupportedCloud(t *testing.T) {
+	if _, err := NewInventoryProvider("azure"); err == nil {
+		t.Fatal("expected unsupported provider error")
+	}
+}

--- a/internal/application/inventory/inventory_skills_test.go
+++ b/internal/application/inventory/inventory_skills_test.go
@@ -1,0 +1,87 @@
+// File: internal/application/inventory/inventory_skills_test.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 02/05/2026
+// Updated: 02/05/2026
+// Purpose: Tests inventory skills against local cloud stubs.
+
+package inventory_test
+
+import (
+	"context"
+	"testing"
+
+	"multix/internal/adapters/outbound/cloud/stub"
+	inventoryapp "multix/internal/application/inventory"
+	"multix/internal/bootstrap"
+)
+
+func TestScanSkillWithCloudStubs(t *testing.T) {
+	providers := newStubInventoryRegistry()
+	skill := inventoryapp.NewScanSkill(providers)
+
+	tests := []struct {
+		provider string
+		service  string
+		wantType string
+		wantName string
+	}{
+		{provider: "aws", service: "compute", wantType: "EC2", wantName: "prod-web-server"},
+		{provider: "gcp", service: "compute", wantType: "computeEngine", wantName: "gce-prod-api"},
+		{provider: "oci", service: "compute", wantType: "Compute", wantName: "prod-web-server-oci"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			result, err := skill.Execute(context.Background(), map[string]any{
+				"provider": tt.provider,
+				"service":  tt.service,
+			})
+			if err != nil {
+				t.Fatalf("unexpected scan error: %v", err)
+			}
+
+			payload := result.(map[string]any)
+			if payload["count"] != 1 {
+				t.Fatalf("expected one scanned resource, got %+v", payload)
+			}
+
+			resources := payload["resources"].([]map[string]any)
+			if resources[0]["type"] != tt.wantType || resources[0]["name"] != tt.wantName {
+				t.Fatalf("unexpected scanned resource: %+v", resources[0])
+			}
+		})
+	}
+}
+
+func TestSummarySkillWithCloudStubs(t *testing.T) {
+	providers := newStubInventoryRegistry()
+	skill := inventoryapp.NewSummarySkill(providers)
+
+	for _, provider := range stub.SupportedInventoryProviders() {
+		t.Run(provider, func(t *testing.T) {
+			result, err := skill.Execute(context.Background(), map[string]any{"provider": provider})
+			if err != nil {
+				t.Fatalf("unexpected summary error: %v", err)
+			}
+
+			payload := result.(map[string]any)
+			if payload["provider"] != provider || payload["total_count"] != 2 {
+				t.Fatalf("unexpected summary payload: %+v", payload)
+			}
+
+			counts := payload["count_by_type"].(map[string]int)
+			if len(counts) != 2 {
+				t.Fatalf("expected two resource type counts, got %+v", counts)
+			}
+		})
+	}
+}
+
+func newStubInventoryRegistry() *bootstrap.BootstrapRegistry {
+	registry := bootstrap.NewBootstrapRegistry()
+	for _, provider := range stub.SupportedInventoryProviders() {
+		registry.RegisterInventory(provider, stub.MustInventoryProvider(provider))
+	}
+	return registry
+}


### PR DESCRIPTION
Closes #29

Summary:
- Adds deterministic AWS, GCP, and OCI inventory stubs for local tests.
- Covers inventory scan and summary skills without live cloud access.

Validation:
- go test ./...