### PR TITLE
refactor(bootstrap): isolate runtime defaults

### DIFF
--- a/internal/bootstrap/app.go
+++ b/internal/bootstrap/app.go
@@ -36,7 +36,9 @@ func BuildApp() (*App, error) {
 	cfg := LoadConfig()
 	log := logger.New("info")
 	rootCmd := root.NewRootCmd()
-	applyRuntimeDefaults(rootCmd, cfg)
+	if err := ApplyRuntimeDefaults(rootCmd, cfg); err != nil {
+		return nil, err
+	}
 
 	providers := BuildProviderRegistry(log)
 	skillRegistry := BuildSkillRegistry(providers)
@@ -71,9 +73,4 @@ func (a *App) Wire() *cobra.Command {
 
 	root.RegisterVersionCmd(a.RootCmd)
 	return a.RootCmd
-}
-
-func applyRuntimeDefaults(rootCmd *cobra.Command, cfg *config.Config) {
-	_ = rootCmd.PersistentFlags().Set("provider", cfg.DefaultCloudProvider)
-	_ = rootCmd.PersistentFlags().Set("output", cfg.DefaultOutputMode)
 }

--- a/internal/bootstrap/runtime_defaults.go
+++ b/internal/bootstrap/runtime_defaults.go
@@ -1,0 +1,63 @@
+// File: internal/bootstrap/runtime_defaults.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 15/03/2026
+// Updated: 02/05/2026
+// Purpose: Applies runtime configuration defaults to the CLI command tree.
+
+package bootstrap
+
+import (
+	"fmt"
+	"multix/internal/domain/config"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	runtimeProviderFlag = "provider"
+	runtimeOutputFlag   = "output"
+)
+
+type runtimeFlagDefault struct {
+	name  string
+	value string
+}
+
+// ApplyRuntimeDefaults maps runtime configuration values onto root CLI defaults.
+func ApplyRuntimeDefaults(rootCmd *cobra.Command, cfg *config.Config) error {
+	if rootCmd == nil {
+		return fmt.Errorf("root command is required")
+	}
+	if cfg == nil {
+		return fmt.Errorf("runtime config is required")
+	}
+
+	defaults := []runtimeFlagDefault{
+		{name: runtimeProviderFlag, value: cfg.DefaultCloudProvider},
+		{name: runtimeOutputFlag, value: cfg.DefaultOutputMode},
+	}
+
+	for _, def := range defaults {
+		if err := setPersistentFlagDefault(rootCmd, def.name, def.value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func setPersistentFlagDefault(rootCmd *cobra.Command, name, value string) error {
+	flags := rootCmd.PersistentFlags()
+	flag := flags.Lookup(name)
+	if flag == nil {
+		return fmt.Errorf("persistent flag %q not found", name)
+	}
+
+	if err := flags.Set(name, value); err != nil {
+		return fmt.Errorf("set persistent flag %q default: %w", name, err)
+	}
+	flag.DefValue = value
+
+	return nil
+}

--- a/internal/bootstrap/runtime_defaults_test.go
+++ b/internal/bootstrap/runtime_defaults_test.go
@@ -1,0 +1,84 @@
+package bootstrap
+
+import (
+	"strings"
+	"testing"
+
+	"multix/cmd/root"
+	"multix/internal/domain/config"
+
+	"github.com/spf13/cobra"
+)
+
+func TestApplyRuntimeDefaults(t *testing.T) {
+	rootCmd := root.NewRootCmd()
+	cfg := &config.Config{
+		DefaultCloudProvider: "oci",
+		DefaultOutputMode:    "table",
+	}
+
+	if err := ApplyRuntimeDefaults(rootCmd, cfg); err != nil {
+		t.Fatalf("unexpected error applying runtime defaults: %v", err)
+	}
+
+	assertFlagValue(t, rootCmd, runtimeProviderFlag, "oci")
+	assertFlagValue(t, rootCmd, runtimeOutputFlag, "table")
+	assertFlagDefaultValue(t, rootCmd, runtimeProviderFlag, "oci")
+	assertFlagDefaultValue(t, rootCmd, runtimeOutputFlag, "table")
+}
+
+func TestApplyRuntimeDefaultsRequiresRootCommand(t *testing.T) {
+	cfg := &config.Config{
+		DefaultCloudProvider: "aws",
+		DefaultOutputMode:    "json",
+	}
+
+	err := ApplyRuntimeDefaults(nil, cfg)
+	if err == nil || !strings.Contains(err.Error(), "root command is required") {
+		t.Fatalf("expected root command error, got %v", err)
+	}
+}
+
+func TestApplyRuntimeDefaultsRequiresConfig(t *testing.T) {
+	err := ApplyRuntimeDefaults(root.NewRootCmd(), nil)
+	if err == nil || !strings.Contains(err.Error(), "runtime config is required") {
+		t.Fatalf("expected runtime config error, got %v", err)
+	}
+}
+
+func TestApplyRuntimeDefaultsRequiresExpectedFlags(t *testing.T) {
+	rootCmd := &cobra.Command{Use: "multix"}
+	cfg := &config.Config{
+		DefaultCloudProvider: "aws",
+		DefaultOutputMode:    "json",
+	}
+
+	err := ApplyRuntimeDefaults(rootCmd, cfg)
+	if err == nil || !strings.Contains(err.Error(), `persistent flag "provider" not found`) {
+		t.Fatalf("expected missing provider flag error, got %v", err)
+	}
+}
+
+func assertFlagValue(t *testing.T, rootCmd *cobra.Command, name, want string) {
+	t.Helper()
+
+	got, err := rootCmd.PersistentFlags().GetString(name)
+	if err != nil {
+		t.Fatalf("expected flag %q to exist: %v", name, err)
+	}
+	if got != want {
+		t.Fatalf("expected flag %q value %q, got %q", name, want, got)
+	}
+}
+
+func assertFlagDefaultValue(t *testing.T, rootCmd *cobra.Command, name, want string) {
+	t.Helper()
+
+	flag := rootCmd.PersistentFlags().Lookup(name)
+	if flag == nil {
+		t.Fatalf("expected flag %q to exist", name)
+	}
+	if flag.DefValue != want {
+		t.Fatalf("expected flag %q default %q, got %q", name, want, flag.DefValue)
+	}
+}


### PR DESCRIPTION
Closes #33

Summary:
- Extracts runtime default application out of app bootstrap wiring.
- Adds tests for CLI default propagation and bootstrap error cases.

Validation:
- go test ./...