### PR TITLE
feat(runtime): propagate structured request IDs

### DIFF
--- a/internal/adapters/inbound/runtime/server.go
+++ b/internal/adapters/inbound/runtime/server.go
@@ -19,7 +19,14 @@ import (
 
 	"multix/internal/adapters/inbound/agent"
 	"multix/internal/platform/logger"
+
+	"github.com/google/uuid"
 )
+
+// RequestIDHeader is the HTTP header used to propagate runtime request IDs.
+const RequestIDHeader = "X-Request-ID"
+
+type requestIDContextKey struct{}
 
 // Server represents the local MULTIX HTTP runtime.
 type Server struct {
@@ -43,10 +50,10 @@ func NewServer(logger logger.Logger, adapter *agent.ToolAdapter, port int) *Serv
 
 // registerRoutes wires up all HTTP endpoints.
 func (s *Server) registerRoutes() {
-	s.mux.HandleFunc("GET /health", s.healthHandler)
-	s.mux.HandleFunc("GET /tools", s.toolsHandler)
-	s.mux.HandleFunc("POST /execute", s.executeHandler)
-	s.mux.HandleFunc("GET /capabilities", s.capabilitiesHandler)
+	s.mux.HandleFunc("GET /health", s.withRequestContext(s.healthHandler))
+	s.mux.HandleFunc("GET /tools", s.withRequestContext(s.toolsHandler))
+	s.mux.HandleFunc("POST /execute", s.withRequestContext(s.executeHandler))
+	s.mux.HandleFunc("GET /capabilities", s.withRequestContext(s.capabilitiesHandler))
 }
 
 // healthHandler provides a basic liveness probe.
@@ -99,10 +106,10 @@ type executeRequest struct {
 
 // executeSuccessResponse defines the canonical success payload.
 type executeSuccessResponse struct {
-	Ok       bool           `json:"ok"`
-	Skill    string         `json:"skill"`
-	Provider string         `json:"provider,omitempty"`
-	Result   any            `json:"result"`
+	Ok       bool   `json:"ok"`
+	Skill    string `json:"skill"`
+	Provider string `json:"provider,omitempty"`
+	Result   any    `json:"result"`
 }
 
 // executeErrorResponse defines the canonical error payload.
@@ -134,6 +141,12 @@ func (s *Server) executeHandler(w http.ResponseWriter, r *http.Request) {
 		req.Params = map[string]any{}
 	}
 
+	if requestID := RequestIDFromContext(r.Context()); requestID != "" {
+		if _, ok := req.Params["request_id"]; !ok {
+			req.Params["request_id"] = requestID
+		}
+	}
+
 	if req.Provider != "" {
 		if _, ok := req.Params["provider"]; !ok {
 			req.Params["provider"] = req.Provider
@@ -142,17 +155,17 @@ func (s *Server) executeHandler(w http.ResponseWriter, r *http.Request) {
 
 	// We still use s.agent.Execute under the hood because ToolAdapter abstractly executes from the registry
 	result, err := s.agent.Execute(r.Context(), req.Skill, req.Params)
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
-		s.logger.Error("Failed to execute tool", err, "skill", req.Skill)
-		
+		s.logger.Error("Failed to execute tool", err, "skill", req.Skill, "request_id", RequestIDFromContext(r.Context()))
+
 		if strings.Contains(strings.ToLower(err.Error()), "not found") {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		
+
 		json.NewEncoder(w).Encode(executeErrorResponse{Ok: false, Error: err.Error()})
 		return
 	}
@@ -167,6 +180,52 @@ func (s *Server) executeHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("Failed to encode execute response", err)
 	}
+}
+
+// RequestIDFromContext returns the runtime request ID attached to ctx, if present.
+func RequestIDFromContext(ctx context.Context) string {
+	requestID, _ := ctx.Value(requestIDContextKey{}).(string)
+	return requestID
+}
+
+func (s *Server) withRequestContext(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		requestID := strings.TrimSpace(r.Header.Get(RequestIDHeader))
+		if requestID == "" {
+			requestID = uuid.NewString()
+		}
+
+		w.Header().Set(RequestIDHeader, requestID)
+		ctx := context.WithValue(r.Context(), requestIDContextKey{}, requestID)
+		req := r.WithContext(ctx)
+		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+		started := time.Now()
+
+		requestLogger := s.logger.With(
+			"request_id", requestID,
+			"method", r.Method,
+			"path", r.URL.Path,
+		)
+		requestLogger.Info("Runtime request started")
+
+		next(recorder, req)
+
+		requestLogger.Info(
+			"Runtime request completed",
+			"status", recorder.statusCode,
+			"duration_ms", time.Since(started).Milliseconds(),
+		)
+	}
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
 }
 
 // Run starts the HTTP server and blocks until graceful shutdown or failure.

--- a/internal/adapters/inbound/runtime/server_test.go
+++ b/internal/adapters/inbound/runtime/server_test.go
@@ -20,16 +20,20 @@ import (
 	"multix/internal/platform/logger"
 )
 
-type mockSkill struct {}
-func (m *mockSkill) Name() string { return "test.skill" }
+type mockSkill struct{}
+
+func (m *mockSkill) Name() string        { return "test.skill" }
 func (m *mockSkill) Description() string { return "Mock skill" }
-func (m *mockSkill) InputSchema() any { return nil }
+func (m *mockSkill) InputSchema() any    { return nil }
 func (m *mockSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
 	provider, _ := input["provider"].(string)
+	requestID, _ := input["request_id"].(string)
 	return map[string]string{
-		"msg": "hello from mock", 
-		"echo_key": input["key"].(string),
-		"echo_provider": provider,
+		"msg":                "hello from mock",
+		"echo_key":           input["key"].(string),
+		"echo_provider":      provider,
+		"echo_request_id":    requestID,
+		"context_request_id": RequestIDFromContext(ctx),
 	}, nil
 }
 
@@ -67,6 +71,9 @@ func TestHealthHandler(t *testing.T) {
 	if mode, ok := response["mode"]; !ok || mode != "runtime" {
 		t.Errorf("handler returned unexpected mode: got %v", rr.Body.String())
 	}
+	if requestID := rr.Header().Get(RequestIDHeader); requestID == "" {
+		t.Fatal("expected generated request ID response header")
+	}
 }
 
 func TestHealthHandler_WrongMethod(t *testing.T) {
@@ -88,7 +95,7 @@ func TestHealthHandler_WrongMethod(t *testing.T) {
 
 func TestToolsHandler(t *testing.T) {
 	log := logger.New("error")
-	
+
 	// Create a dummy ToolAdapter with no skills, which should just return an empty JS array []
 	adapter := agent.NewToolAdapter(nil, nil)
 	s := NewServer(log, adapter, 8080)
@@ -124,7 +131,7 @@ func TestToolsHandler(t *testing.T) {
 
 func TestExecuteHandler_Success(t *testing.T) {
 	log := logger.New("error")
-	
+
 	// Create a real registry and executor, and prep it with a mock skill
 	registry := domainSkills.NewRegistry()
 	registry.Register(&mockSkill{})
@@ -150,7 +157,7 @@ func TestExecuteHandler_Success(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse success response: %v", err)
 	}
-	
+
 	if !resp.Ok || resp.Skill != "test.skill" || resp.Provider != "aws" {
 		t.Errorf("unexpected success envelope: %+v", resp)
 	}
@@ -158,6 +165,49 @@ func TestExecuteHandler_Success(t *testing.T) {
 	resultMap, ok := resp.Result.(map[string]any)
 	if !ok || resultMap["echo_provider"] != "aws" {
 		t.Errorf("expected provider to be injected into params, got: %+v", resp.Result)
+	}
+	if rr.Header().Get(RequestIDHeader) == "" {
+		t.Fatal("expected generated request ID response header")
+	}
+}
+
+func TestExecuteHandler_PropagatesRequestID(t *testing.T) {
+	log := logger.New("error")
+
+	registry := domainSkills.NewRegistry()
+	registry.Register(&mockSkill{})
+	executor := appSkills.NewExecutor(registry)
+	adapter := agent.NewToolAdapter(registry, executor)
+
+	s := NewServer(log, adapter, 8080)
+
+	req, err := http.NewRequest(http.MethodPost, "/execute", strings.NewReader(`{"skill": "test.skill", "provider": "aws", "params": {"key": "value"}}`))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set(RequestIDHeader, "req-test-123")
+
+	rr := httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d. Body: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get(RequestIDHeader) != "req-test-123" {
+		t.Fatalf("expected request ID response header to be propagated, got %q", rr.Header().Get(RequestIDHeader))
+	}
+
+	var resp executeSuccessResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse success response: %v", err)
+	}
+
+	resultMap, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %+v", resp.Result)
+	}
+	if resultMap["echo_request_id"] != "req-test-123" || resultMap["context_request_id"] != "req-test-123" {
+		t.Fatalf("expected request ID in params and context, got %+v", resultMap)
 	}
 }
 
@@ -211,7 +261,7 @@ func TestExecuteHandler_UnknownSkill(t *testing.T) {
 	rr := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr, req)
 
-	// The executeHandler string matches on "not found" mapped to 404. 
+	// The executeHandler string matches on "not found" mapped to 404.
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for missing real skill resolution, got %d", rr.Code)
 	}
@@ -222,4 +272,3 @@ func TestExecuteHandler_UnknownSkill(t *testing.T) {
 		t.Errorf("expected Ok=false")
 	}
 }
-


### PR DESCRIPTION
Closes #36

Summary:
- Adds X-Request-ID propagation across runtime endpoints.
- Injects request_id into execute params and context for auditable agent actions.
- Logs runtime request start/completion with structured request fields.

Validation:
- go test ./...