### PR TITLE
feat(runtime): expose prometheus metrics

### DIFF
--- a/internal/adapters/inbound/runtime/server.go
+++ b/internal/adapters/inbound/runtime/server.go
@@ -12,8 +12,10 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -23,19 +25,21 @@ import (
 
 // Server represents the local MULTIX HTTP runtime.
 type Server struct {
-	logger logger.Logger
-	agent  *agent.ToolAdapter
-	mux    *http.ServeMux
-	port   int
+	logger  logger.Logger
+	agent   *agent.ToolAdapter
+	mux     *http.ServeMux
+	metrics *Metrics
+	port    int
 }
 
 // NewServer initializes a new runtime Server.
 func NewServer(logger logger.Logger, adapter *agent.ToolAdapter, port int) *Server {
 	s := &Server{
-		logger: logger,
-		agent:  adapter,
-		mux:    http.NewServeMux(),
-		port:   port,
+		logger:  logger,
+		agent:   adapter,
+		mux:     http.NewServeMux(),
+		metrics: NewMetrics(),
+		port:    port,
 	}
 	s.registerRoutes()
 	return s
@@ -47,6 +51,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /tools", s.toolsHandler)
 	s.mux.HandleFunc("POST /execute", s.executeHandler)
 	s.mux.HandleFunc("GET /capabilities", s.capabilitiesHandler)
+	s.mux.HandleFunc("GET /metrics", s.metricsHandler)
 }
 
 // healthHandler provides a basic liveness probe.
@@ -90,6 +95,15 @@ func (s *Server) toolsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// metricsHandler exposes Prometheus-compatible runtime metrics.
+func (s *Server) metricsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(s.metrics.Prometheus())); err != nil {
+		s.logger.Error("Failed to write metrics response", err)
+	}
+}
+
 // executeRequest defines the canonical payload for the /execute endpoint.
 type executeRequest struct {
 	Skill    string         `json:"skill"`
@@ -99,10 +113,10 @@ type executeRequest struct {
 
 // executeSuccessResponse defines the canonical success payload.
 type executeSuccessResponse struct {
-	Ok       bool           `json:"ok"`
-	Skill    string         `json:"skill"`
-	Provider string         `json:"provider,omitempty"`
-	Result   any            `json:"result"`
+	Ok       bool   `json:"ok"`
+	Skill    string `json:"skill"`
+	Provider string `json:"provider,omitempty"`
+	Result   any    `json:"result"`
 }
 
 // executeErrorResponse defines the canonical error payload.
@@ -142,21 +156,23 @@ func (s *Server) executeHandler(w http.ResponseWriter, r *http.Request) {
 
 	// We still use s.agent.Execute under the hood because ToolAdapter abstractly executes from the registry
 	result, err := s.agent.Execute(r.Context(), req.Skill, req.Params)
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
+		s.metrics.RecordSkillInvocation(req.Skill, "error")
 		s.logger.Error("Failed to execute tool", err, "skill", req.Skill)
-		
+
 		if strings.Contains(strings.ToLower(err.Error()), "not found") {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		
+
 		json.NewEncoder(w).Encode(executeErrorResponse{Ok: false, Error: err.Error()})
 		return
 	}
 
+	s.metrics.RecordSkillInvocation(req.Skill, "success")
 	w.WriteHeader(http.StatusOK)
 	resp := executeSuccessResponse{
 		Ok:       true,
@@ -167,6 +183,69 @@ func (s *Server) executeHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("Failed to encode execute response", err)
 	}
+}
+
+type metricKey struct {
+	skill  string
+	status string
+}
+
+// Metrics stores runtime counters exposed through the Prometheus text format.
+type Metrics struct {
+	mu               sync.Mutex
+	skillInvocations map[metricKey]int
+}
+
+// NewMetrics creates an empty runtime metrics store.
+func NewMetrics() *Metrics {
+	return &Metrics{skillInvocations: make(map[metricKey]int)}
+}
+
+// RecordSkillInvocation increments the skill invocation counter for a status.
+func (m *Metrics) RecordSkillInvocation(skill, status string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.skillInvocations[metricKey{skill: skill, status: status}]++
+}
+
+// Prometheus renders the metrics store in Prometheus text exposition format.
+func (m *Metrics) Prometheus() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var b strings.Builder
+	b.WriteString("# HELP multix_skill_invocations_total Total skill invocation attempts through the runtime execute endpoint.\n")
+	b.WriteString("# TYPE multix_skill_invocations_total counter\n")
+
+	keys := make([]metricKey, 0, len(m.skillInvocations))
+	for key := range m.skillInvocations {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].skill == keys[j].skill {
+			return keys[i].status < keys[j].status
+		}
+		return keys[i].skill < keys[j].skill
+	})
+
+	for _, key := range keys {
+		b.WriteString(`multix_skill_invocations_total{skill="`)
+		b.WriteString(escapeMetricLabel(key.skill))
+		b.WriteString(`",status="`)
+		b.WriteString(escapeMetricLabel(key.status))
+		b.WriteString(`"} `)
+		b.WriteString(strconv.Itoa(m.skillInvocations[key]))
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func escapeMetricLabel(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, "\n", `\n`)
+	return strings.ReplaceAll(value, `"`, `\"`)
 }
 
 // Run starts the HTTP server and blocks until graceful shutdown or failure.

--- a/internal/adapters/inbound/runtime/server_test.go
+++ b/internal/adapters/inbound/runtime/server_test.go
@@ -20,15 +20,16 @@ import (
 	"multix/internal/platform/logger"
 )
 
-type mockSkill struct {}
-func (m *mockSkill) Name() string { return "test.skill" }
+type mockSkill struct{}
+
+func (m *mockSkill) Name() string        { return "test.skill" }
 func (m *mockSkill) Description() string { return "Mock skill" }
-func (m *mockSkill) InputSchema() any { return nil }
+func (m *mockSkill) InputSchema() any    { return nil }
 func (m *mockSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
 	provider, _ := input["provider"].(string)
 	return map[string]string{
-		"msg": "hello from mock", 
-		"echo_key": input["key"].(string),
+		"msg":           "hello from mock",
+		"echo_key":      input["key"].(string),
 		"echo_provider": provider,
 	}, nil
 }
@@ -88,7 +89,7 @@ func TestHealthHandler_WrongMethod(t *testing.T) {
 
 func TestToolsHandler(t *testing.T) {
 	log := logger.New("error")
-	
+
 	// Create a dummy ToolAdapter with no skills, which should just return an empty JS array []
 	adapter := agent.NewToolAdapter(nil, nil)
 	s := NewServer(log, adapter, 8080)
@@ -122,9 +123,32 @@ func TestToolsHandler(t *testing.T) {
 	}
 }
 
+func TestMetricsHandler(t *testing.T) {
+	log := logger.New("error")
+	s := NewServer(log, agent.NewToolAdapter(nil, nil), 8080)
+
+	req, err := http.NewRequest(http.MethodGet, "/metrics", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", rr.Code)
+	}
+	if ctype := rr.Header().Get("Content-Type"); ctype != "text/plain; version=0.0.4; charset=utf-8" {
+		t.Fatalf("unexpected content type: %q", ctype)
+	}
+	if !strings.Contains(rr.Body.String(), "# TYPE multix_skill_invocations_total counter") {
+		t.Fatalf("expected prometheus metric type, got %s", rr.Body.String())
+	}
+}
+
 func TestExecuteHandler_Success(t *testing.T) {
 	log := logger.New("error")
-	
+
 	// Create a real registry and executor, and prep it with a mock skill
 	registry := domainSkills.NewRegistry()
 	registry.Register(&mockSkill{})
@@ -150,7 +174,7 @@ func TestExecuteHandler_Success(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("failed to parse success response: %v", err)
 	}
-	
+
 	if !resp.Ok || resp.Skill != "test.skill" || resp.Provider != "aws" {
 		t.Errorf("unexpected success envelope: %+v", resp)
 	}
@@ -158,6 +182,43 @@ func TestExecuteHandler_Success(t *testing.T) {
 	resultMap, ok := resp.Result.(map[string]any)
 	if !ok || resultMap["echo_provider"] != "aws" {
 		t.Errorf("expected provider to be injected into params, got: %+v", resp.Result)
+	}
+}
+
+func TestExecuteHandler_RecordsMetrics(t *testing.T) {
+	log := logger.New("error")
+
+	registry := domainSkills.NewRegistry()
+	registry.Register(&mockSkill{})
+	executor := appSkills.NewExecutor(registry)
+	adapter := agent.NewToolAdapter(registry, executor)
+
+	s := NewServer(log, adapter, 8080)
+
+	successReq, _ := http.NewRequest(http.MethodPost, "/execute", strings.NewReader(`{"skill": "test.skill", "provider": "aws", "params": {"key": "value"}}`))
+	successRR := httptest.NewRecorder()
+	s.mux.ServeHTTP(successRR, successReq)
+	if successRR.Code != http.StatusOK {
+		t.Fatalf("expected success execution, got %d: %s", successRR.Code, successRR.Body.String())
+	}
+
+	errorReq, _ := http.NewRequest(http.MethodPost, "/execute", strings.NewReader(`{"skill":"invalid.skill"}`))
+	errorRR := httptest.NewRecorder()
+	s.mux.ServeHTTP(errorRR, errorReq)
+	if errorRR.Code != http.StatusNotFound {
+		t.Fatalf("expected not found execution, got %d: %s", errorRR.Code, errorRR.Body.String())
+	}
+
+	metricsReq, _ := http.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsRR := httptest.NewRecorder()
+	s.mux.ServeHTTP(metricsRR, metricsReq)
+
+	body := metricsRR.Body.String()
+	if !strings.Contains(body, `multix_skill_invocations_total{skill="test.skill",status="success"} 1`) {
+		t.Fatalf("expected success metric, got %s", body)
+	}
+	if !strings.Contains(body, `multix_skill_invocations_total{skill="invalid.skill",status="error"} 1`) {
+		t.Fatalf("expected error metric, got %s", body)
 	}
 }
 
@@ -211,7 +272,7 @@ func TestExecuteHandler_UnknownSkill(t *testing.T) {
 	rr := httptest.NewRecorder()
 	s.mux.ServeHTTP(rr, req)
 
-	// The executeHandler string matches on "not found" mapped to 404. 
+	// The executeHandler string matches on "not found" mapped to 404.
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("expected 404 for missing real skill resolution, got %d", rr.Code)
 	}
@@ -222,4 +283,3 @@ func TestExecuteHandler_UnknownSkill(t *testing.T) {
 		t.Errorf("expected Ok=false")
 	}
 }
-


### PR DESCRIPTION
Closes #37

Summary:
- Adds a Prometheus-compatible /metrics endpoint to multix serve.
- Tracks skill invocation counts by skill and status.
- Covers metrics rendering and execute success/error counters.

Validation:
- go test ./...