### PR TITLE
ci: add cross-platform release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label to embed in binaries"
+        required: true
+        default: "dev"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build binary
+        env:
+          CGO_ENABLED: "0"
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          mkdir -p build
+          go build \
+            -ldflags "-s -w -X multix/pkg/version.Version=${VERSION}" \
+            -o "build/multix-${GOOS}-${GOARCH}" \
+            ./cmd/multix/main.go
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: multix-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build/multix-${{ matrix.goos }}-${{ matrix.goarch }}
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/multix-*

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ VERSION?=1.0.0-beta
 BUILD_DIR:=build
 GO:=go
 GOFLAGS:=-ldflags "-s -w -X multix/pkg/version.Version=$(VERSION)"
+CROSS_PLATFORMS:=linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 
-.PHONY: all build run test test-race smoke-oci lint fmt vet vuln tidy clean install help
+.PHONY: all build build-cross run test test-race smoke-oci lint fmt vet vuln tidy clean install help
 .PHONY: ai-help ai-plan ai-implement ai-review ai-safe-fix ai-prompts ai-comments ai-review-comments
 
 all: clean fmt vet tidy test build
@@ -16,6 +17,18 @@ build: ## Build the Enterprise CLI binary
 	@mkdir -p $(BUILD_DIR)
 	@$(GO) build $(GOFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./cmd/multix/main.go
 	@echo "==> Build complete: $(BUILD_DIR)/$(BINARY_NAME)"
+
+build-cross: ## Cross-compile release binaries for linux/darwin amd64/arm64
+	@echo "==> Cross-compiling $(BINARY_NAME) $(VERSION)..."
+	@mkdir -p $(BUILD_DIR)
+	@for platform in $(CROSS_PLATFORMS); do \
+		GOOS=$${platform%/*}; \
+		GOARCH=$${platform#*/}; \
+		output="$(BUILD_DIR)/$(BINARY_NAME)-$${GOOS}-$${GOARCH}"; \
+		echo "==> Building $${output}"; \
+		CGO_ENABLED=0 GOOS=$${GOOS} GOARCH=$${GOARCH} $(GO) build $(GOFLAGS) -o "$${output}" ./cmd/multix/main.go; \
+	done
+	@echo "==> Cross-compilation complete: $(BUILD_DIR)/"
 
 run: build ## Build and run the CLI (usage: make run ARGS="cloud list")
 	@$(BUILD_DIR)/$(BINARY_NAME) $(ARGS)


### PR DESCRIPTION
Closes #35

Summary:
- Adds a local build-cross target for linux/darwin amd64/arm64 binaries.
- Adds a release workflow that builds and uploads release artifacts from version tags.

Validation:
- go test ./...
- make build-cross