### PR TITLE
test(inventory): add offline e2e and CI foundation

### DIFF
--- a/.agent/COMMANDS.md
+++ b/.agent/COMMANDS.md
@@ -30,6 +30,11 @@ Typical safe workflow:
    - `make tidy`
 5. if security-sensitive:
    - `make vuln`
+6. commit changes on a focused branch
+7. open a GitHub pull request before considering the activity delivered
+
+See also:
+- `.agent/PULL_REQUESTS.md`
 
 ---
 

--- a/.agent/PULL_REQUESTS.md
+++ b/.agent/PULL_REQUESTS.md
@@ -1,0 +1,49 @@
+# Multix Pull Request Rules
+
+## 1. Default Delivery Rule
+
+Every completed implementation activity must be delivered through a GitHub pull
+request.
+
+Do not treat local commits, local branch changes, or direct pushes as the final
+delivery unless the user explicitly asks for that exception.
+
+---
+
+## 2. Branch Rule
+
+Use a focused branch for each activity or tightly related group of issues.
+
+Branch names should describe the issue or scope, for example:
+- `feature/24-27-e2e-ci-foundation`
+- `docs/project-historical-resolution-prs`
+- `fix/runtime-request-id-tests`
+
+---
+
+## 3. PR Body Rule
+
+Every PR must include:
+- a short summary of the delivered changes
+- validation commands that were executed
+- linked issues using `Closes #NN` when the PR is intended to close them
+- any known limitation, blocked CI, or follow-up risk
+
+---
+
+## 4. Project Rule
+
+When the issue is tracked in GitHub Projects:
+- move the item to `In Progress` after opening the PR
+- keep it out of `Done` until the PR is merged
+- after merge, confirm the item has a linked PR before moving it to `Done`
+
+---
+
+## 5. Final Response Rule
+
+When finishing an activity, report:
+- PR number and URL
+- linked issues
+- validation results
+- Project status updates, when applicable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test, Vet, and Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check formatting
+        run: |
+          test -z "$(gofmt -l .)"
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run vet
+        run: go vet ./...
+
+      - name: Build binary
+        run: make build
+
+      - name: Cross-compile release targets
+        run: make build-cross

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MULTIX — AI-Native Multi-Cloud Skill Runtime
 
+[![CI](https://github.com/marciozampiron/multix/actions/workflows/ci.yml/badge.svg)](https://github.com/marciozampiron/multix/actions/workflows/ci.yml)
+
 ## 1. Title + Tagline
 
 Enterprise-grade multi-cloud operations for humans, command-line workflows, and AI agents.

--- a/internal/adapters/inbound/runtime/inventory_e2e_test.go
+++ b/internal/adapters/inbound/runtime/inventory_e2e_test.go
@@ -1,0 +1,175 @@
+// File: internal/adapters/inbound/runtime/inventory_e2e_test.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 03/05/2026
+// Purpose: E2E coverage for inventory execution through the local runtime using cloud stubs.
+
+package runtime
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"multix/internal/adapters/inbound/agent"
+	"multix/internal/adapters/outbound/cloud/stub"
+	inventoryapp "multix/internal/application/inventory"
+	appSkills "multix/internal/application/skills"
+	domainSkills "multix/internal/domain/skills"
+	"multix/internal/platform/logger"
+	"multix/internal/ports/outbound"
+)
+
+func TestInventoryRuntimeE2EWithAWSAndGCPStubs(t *testing.T) {
+	server := newInventoryStubRuntime(t)
+
+	tests := []struct {
+		provider string
+		service  string
+		wantType string
+		wantName string
+		want     float64
+	}{
+		{provider: "aws", service: "compute", wantType: "EC2", wantName: "prod-web-server", want: 2},
+		{provider: "aws", service: "storage", wantType: "S3", wantName: "prod-logs", want: 2},
+		{provider: "gcp", service: "compute", wantType: "computeEngine", wantName: "gce-prod-api", want: 2},
+		{provider: "gcp", service: "storage", wantType: "cloudStorage", wantName: "gcs-backup-vault", want: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.service, func(t *testing.T) {
+			resp := executeRuntimeSkill(t, server, map[string]any{
+				"skill":    "inventory.scan",
+				"provider": tt.provider,
+				"params": map[string]any{
+					"service": tt.service,
+				},
+			})
+
+			if !resp.Ok || resp.Skill != "inventory.scan" || resp.Provider != tt.provider {
+				t.Fatalf("unexpected execute envelope: %+v", resp)
+			}
+
+			result := resultMap(t, resp.Result)
+			if result["count"] != tt.want {
+				t.Fatalf("expected %v resources, got %+v", tt.want, result)
+			}
+
+			resources, ok := result["resources"].([]any)
+			if !ok || len(resources) != int(tt.want) {
+				t.Fatalf("unexpected resources payload: %+v", result["resources"])
+			}
+
+			first := resultMap(t, resources[0])
+			if first["type"] != tt.wantType || first["name"] != tt.wantName {
+				t.Fatalf("unexpected first resource: %+v", first)
+			}
+			for _, key := range []string{"id", "type", "region", "name", "status"} {
+				if first[key] == "" {
+					t.Fatalf("resource missing %q field: %+v", key, first)
+				}
+			}
+		})
+	}
+}
+
+func TestInventoryRuntimeSummaryE2EWithAWSAndGCPStubs(t *testing.T) {
+	server := newInventoryStubRuntime(t)
+
+	for _, provider := range []string{"aws", "gcp"} {
+		t.Run(provider, func(t *testing.T) {
+			resp := executeRuntimeSkill(t, server, map[string]any{
+				"skill":    "inventory.summary",
+				"provider": provider,
+			})
+
+			result := resultMap(t, resp.Result)
+			if result["provider"] != provider || result["total_count"] != float64(4) {
+				t.Fatalf("unexpected summary result: %+v", result)
+			}
+
+			counts := resultMap(t, result["count_by_type"])
+			if len(counts) != 2 {
+				t.Fatalf("expected two inventory type buckets, got %+v", counts)
+			}
+		})
+	}
+}
+
+func newInventoryStubRuntime(t *testing.T) *Server {
+	t.Helper()
+
+	providers := &inventoryStubRegistry{inventory: map[string]outbound.InventoryProvider{}}
+	for _, provider := range []string{"aws", "gcp"} {
+		providers.inventory[provider] = stub.MustInventoryProvider(provider)
+	}
+
+	registry := domainSkills.NewRegistry()
+	registry.Register(inventoryapp.NewScanSkill(providers))
+	registry.Register(inventoryapp.NewSummarySkill(providers))
+
+	executor := appSkills.NewExecutor(registry)
+	adapter := agent.NewToolAdapter(registry, executor)
+	return NewServer(logger.New("error"), adapter, 8080)
+}
+
+type inventoryStubRegistry struct {
+	inventory map[string]outbound.InventoryProvider
+}
+
+func (r *inventoryStubRegistry) GetCloudInventoryProvider(name string) (outbound.InventoryProvider, error) {
+	provider, ok := r.inventory[name]
+	if !ok {
+		return nil, fmt.Errorf("inventory provider not found: %s", name)
+	}
+	return provider, nil
+}
+
+func (r *inventoryStubRegistry) GetCloudAuthProvider(name string) (outbound.AuthProvider, error) {
+	return nil, fmt.Errorf("auth provider not configured for inventory e2e: %s", name)
+}
+
+func (r *inventoryStubRegistry) GetKubernetesProvider(name string) (outbound.K8sProvider, error) {
+	return nil, fmt.Errorf("kubernetes provider not configured for inventory e2e: %s", name)
+}
+
+func (r *inventoryStubRegistry) GetAIProvider(name string) (outbound.AIProvider, error) {
+	return nil, fmt.Errorf("ai provider not configured for inventory e2e: %s", name)
+}
+
+func executeRuntimeSkill(t *testing.T, server *Server, payload map[string]any) executeSuccessResponse {
+	t.Helper()
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/execute", bytes.NewReader(body))
+	req.Header.Set(RequestIDHeader, fmt.Sprintf("test-%s", t.Name()))
+	rr := httptest.NewRecorder()
+	server.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp executeSuccessResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode execute response: %v", err)
+	}
+	return resp
+}
+
+func resultMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+
+	result, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T: %+v", value, value)
+	}
+	return result
+}

--- a/internal/adapters/outbound/cloud/stub/inventory.go
+++ b/internal/adapters/outbound/cloud/stub/inventory.go
@@ -101,11 +101,15 @@ func inventoryFixtures() map[string][]*inventory.Resource {
 	return map[string][]*inventory.Resource{
 		"aws": {
 			newFixtureResource("i-0abc123", "123456789012", "us-east-1", "EC2", "prod-web-server", "RUNNING"),
+			newFixtureResource("i-0def456", "123456789012", "us-west-2", "EC2", "batch-worker-a", "STOPPED"),
 			newFixtureResource("bucket-prod-logs", "123456789012", "us-east-1", "S3", "prod-logs", "ACTIVE"),
+			newFixtureResource("bucket-audit-archive", "123456789012", "us-west-2", "S3", "audit-archive", "ACTIVE"),
 		},
 		"gcp": {
 			newFixtureResource("gce-prod-api", "demo-project", "us-central1", "computeEngine", "gce-prod-api", "RUNNING"),
+			newFixtureResource("gce-batch-worker", "demo-project", "us-east1", "computeEngine", "gce-batch-worker", "TERMINATED"),
 			newFixtureResource("gcs-backup-vault", "demo-project", "us-central1", "cloudStorage", "gcs-backup-vault", "ACTIVE"),
+			newFixtureResource("gcs-audit-archive", "demo-project", "us-east1", "cloudStorage", "gcs-audit-archive", "ACTIVE"),
 		},
 		"oci": {
 			newFixtureResource("ocid1.instance.oc1..stub", "ocid1.tenancy.oc1..stub", "us-ashburn-1", "Compute", "prod-web-server-oci", "RUNNING"),

--- a/internal/adapters/outbound/cloud/stub/inventory_test.go
+++ b/internal/adapters/outbound/cloud/stub/inventory_test.go
@@ -18,10 +18,13 @@ func TestInventoryProviderFixtures(t *testing.T) {
 		computeType  string
 		storageType  string
 		expectedName string
+		computeCount int
+		storageCount int
+		totalCount   int
 	}{
-		{provider: "aws", computeType: "EC2", storageType: "S3", expectedName: "prod-web-server"},
-		{provider: "gcp", computeType: "computeEngine", storageType: "cloudStorage", expectedName: "gce-prod-api"},
-		{provider: "oci", computeType: "Compute", storageType: "Bucket", expectedName: "prod-web-server-oci"},
+		{provider: "aws", computeType: "EC2", storageType: "S3", expectedName: "prod-web-server", computeCount: 2, storageCount: 2, totalCount: 4},
+		{provider: "gcp", computeType: "computeEngine", storageType: "cloudStorage", expectedName: "gce-prod-api", computeCount: 2, storageCount: 2, totalCount: 4},
+		{provider: "oci", computeType: "Compute", storageType: "Bucket", expectedName: "prod-web-server-oci", computeCount: 1, storageCount: 1, totalCount: 2},
 	}
 
 	for _, tt := range tests {
@@ -36,7 +39,7 @@ func TestInventoryProviderFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected compute list error: %v", err)
 			}
-			if len(compute) != 1 || compute[0].Type != tt.computeType || compute[0].Name != tt.expectedName {
+			if len(compute) != tt.computeCount || compute[0].Type != tt.computeType || compute[0].Name != tt.expectedName {
 				t.Fatalf("unexpected compute resources: %+v", compute)
 			}
 
@@ -44,7 +47,7 @@ func TestInventoryProviderFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected storage list error: %v", err)
 			}
-			if len(storage) != 1 || storage[0].Type != tt.storageType {
+			if len(storage) != tt.storageCount || storage[0].Type != tt.storageType {
 				t.Fatalf("unexpected storage resources: %+v", storage)
 			}
 
@@ -52,10 +55,10 @@ func TestInventoryProviderFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected scan error: %v", err)
 			}
-			if summary.ProviderName != tt.provider || summary.Total != 2 {
+			if summary.ProviderName != tt.provider || summary.Total != tt.totalCount {
 				t.Fatalf("unexpected summary: %+v", summary)
 			}
-			if summary.CountByType[tt.computeType] != 1 || summary.CountByType[tt.storageType] != 1 {
+			if summary.CountByType[tt.computeType] != tt.computeCount || summary.CountByType[tt.storageType] != tt.storageCount {
 				t.Fatalf("unexpected summary counts: %+v", summary.CountByType)
 			}
 		})

--- a/internal/application/inventory/inventory_skills_test.go
+++ b/internal/application/inventory/inventory_skills_test.go
@@ -25,10 +25,11 @@ func TestScanSkillWithCloudStubs(t *testing.T) {
 		service  string
 		wantType string
 		wantName string
+		want     int
 	}{
-		{provider: "aws", service: "compute", wantType: "EC2", wantName: "prod-web-server"},
-		{provider: "gcp", service: "compute", wantType: "computeEngine", wantName: "gce-prod-api"},
-		{provider: "oci", service: "compute", wantType: "Compute", wantName: "prod-web-server-oci"},
+		{provider: "aws", service: "compute", wantType: "EC2", wantName: "prod-web-server", want: 2},
+		{provider: "gcp", service: "compute", wantType: "computeEngine", wantName: "gce-prod-api", want: 2},
+		{provider: "oci", service: "compute", wantType: "Compute", wantName: "prod-web-server-oci", want: 1},
 	}
 
 	for _, tt := range tests {
@@ -42,8 +43,8 @@ func TestScanSkillWithCloudStubs(t *testing.T) {
 			}
 
 			payload := result.(map[string]any)
-			if payload["count"] != 1 {
-				t.Fatalf("expected one scanned resource, got %+v", payload)
+			if payload["count"] != tt.want {
+				t.Fatalf("expected %d scanned resources, got %+v", tt.want, payload)
 			}
 
 			resources := payload["resources"].([]map[string]any)
@@ -66,7 +67,11 @@ func TestSummarySkillWithCloudStubs(t *testing.T) {
 			}
 
 			payload := result.(map[string]any)
-			if payload["provider"] != provider || payload["total_count"] != 2 {
+			wantTotal := 2
+			if provider == "aws" || provider == "gcp" {
+				wantTotal = 4
+			}
+			if payload["provider"] != provider || payload["total_count"] != wantTotal {
 				t.Fatalf("unexpected summary payload: %+v", payload)
 			}
 


### PR DESCRIPTION
## Summary
- Adds offline AWS/GCP inventory E2E coverage through the local runtime `/execute` endpoint using deterministic cloud stubs.
- Expands AWS/GCP inventory fixtures to simulate larger local accounts with compute and storage resources.
- Adds a basic CI workflow for PRs and main pushes: gofmt check, `go test ./...`, `go vet ./...`, `make build`, and `make build-cross`.
- Adds the CI badge to README.

## Validation
- go test ./...
- go vet ./...
- make build
- make build-cross
- git diff --check

Closes #24
Closes #27