### PR TITLE
[v0.9] feat(cost): cost.focus_report with real AWS Cost Explorer + honest GCP/OCI envelopes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu8Ti4pcLPIIyoKZrA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 h1:rUg81vwoGgCmnQxsVl+B65QF8Qh+zYCluhyAcxsk79o=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8/go.mod h1:V+bKJ05kIC6K0LH8TB3D5boy7F8BhrZeecoXLz1NlB4=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1 h1:gQ9fSyFk3Y9Vm2fVbphBeJfXJlkJvEvC35TszBVjprg=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.299.1/go.mod h1:Y95W0Hm6FYLPa6o0hbnJ+sWgmdc4ifcLFjGkdobWVhY=
 github.com/aws/aws-sdk-go-v2/service/eks v1.83.0 h1:mS5rkyFt+NYryy0p4n8o80tJjBmXiQrRCQjP8jZcSLY=

--- a/internal/adapters/inbound/cli/serve_cmd.go
+++ b/internal/adapters/inbound/cli/serve_cmd.go
@@ -26,7 +26,7 @@ func NewServeCmd(logger logger.Logger, adapter *agent.ToolAdapter) *cobra.Comman
 			return server.Run(cmd.Context())
 		},
 	}
-	
+
 	cmd.Flags().IntVar(&port, "port", 8080, "Port to assign to the HTTP runtime server")
 	return cmd
 }

--- a/internal/adapters/outbound/cloud/gcp/inventory_test.go
+++ b/internal/adapters/outbound/cloud/gcp/inventory_test.go
@@ -132,11 +132,11 @@ func TestGCPAdapter_List_ComputeError(t *testing.T) {
 
 func TestGCPAdapter_RegionFromZone(t *testing.T) {
 	cases := map[string]string{
-		"us-central1-a": "us-central1",
+		"us-central1-a":  "us-central1",
 		"europe-west4-b": "europe-west4",
-		"asia-east1-c":  "asia-east1",
-		"us-central1":   "us-central1", // not zone-shaped → unchanged
-		"":              "",
+		"asia-east1-c":   "asia-east1",
+		"us-central1":    "us-central1", // not zone-shaped → unchanged
+		"":               "",
 	}
 	for input, want := range cases {
 		if got := regionFromZone(input); got != want {

--- a/internal/adapters/outbound/cloud/oci/adapter.go
+++ b/internal/adapters/outbound/cloud/oci/adapter.go
@@ -28,12 +28,12 @@ import (
 
 // ociInstance is a minimal projection of a Compute instance for inventory output.
 type ociInstance struct {
-	ID            string
-	Name          string
-	Region        string
+	ID             string
+	Name           string
+	Region         string
 	LifecycleState string
-	FreeformTags  map[string]string
-	TimeCreated   time.Time
+	FreeformTags   map[string]string
+	TimeCreated    time.Time
 }
 
 // ociBucket is a minimal projection of an Object Storage bucket for inventory output.
@@ -221,14 +221,14 @@ func (a *adapter) Login(ctx context.Context, creds auth.Credentials) (*auth.Sess
 // Whoami returns the active OCI identity by inspecting the configuration provider.
 func (a *adapter) Whoami(ctx context.Context) (*auth.Identity, error) {
 	a.logger.Info("Retrieving OCI caller identity")
-	
+
 	cfg := a.cfgProviderFunc()
-	
+
 	tenancyID, err := cfg.TenancyOCID()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve OCI tenancy OCID: %w", err)
 	}
-	
+
 	userID, err := cfg.UserOCID()
 	if err != nil {
 		// In instance principal or resource principal scenarios, this might be empty
@@ -248,7 +248,7 @@ func (a *adapter) Whoami(ctx context.Context) (*auth.Identity, error) {
 // Validate validates OCI credentials by making a real API call to GetUser.
 func (a *adapter) Validate(ctx context.Context) (*auth.ValidationResult, error) {
 	a.logger.Info("Validating OCI credentials via Identity API")
-	
+
 	cfg := a.cfgProviderFunc()
 	client, err := a.identityClientFunc(cfg)
 	if err != nil {

--- a/internal/application/cost/focus_report_skill.go
+++ b/internal/application/cost/focus_report_skill.go
@@ -1,0 +1,283 @@
+// File: internal/application/cost/focus_report_skill.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 02/05/2026
+// Updated: 02/05/2026
+// Purpose: cost.focus_report skill — multi-cloud FOCUS-aligned billing aggregation.
+
+package cost
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"multix/internal/domain/cost"
+	"multix/internal/domain/skills"
+	"multix/internal/ports/outbound"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+const (
+	periodCurrentMonth = "current_month"
+	periodLast30Days   = "last_30_days"
+	periodLastMonth    = "last_month"
+)
+
+// FocusReportSkill is the v1 implementation of cost.focus_report:
+//
+//   - AWS: real Cost Explorer GetCostAndUsage call grouped by SERVICE + REGION.
+//   - GCP / OCI: structured `supported: false` envelope pointing at the
+//     follow-up issues that will wire their billing APIs.
+//
+// The skill is intentionally explicit about the partial coverage so the
+// agent doesn't conflate "no spend" with "not yet implemented".
+type FocusReportSkill struct {
+	providers outbound.ProviderRegistry
+	// awsCostFetchFunc is a testable seam for the Cost Explorer call.
+	awsCostFetchFunc func(ctx context.Context, period string) ([]cost.FocusBillingRow, error)
+}
+
+// NewFocusReportSkill creates the skill wired with the default AWS Cost
+// Explorer client.
+func NewFocusReportSkill(pr outbound.ProviderRegistry) skills.Skill {
+	s := &FocusReportSkill{providers: pr}
+	s.awsCostFetchFunc = s.defaultAWSCostFetch
+	return s
+}
+
+func (s *FocusReportSkill) Name() string { return "cost.focus_report" }
+
+func (s *FocusReportSkill) Description() string {
+	return "Generates a FOCUS-aligned billing report. AWS uses Cost Explorer (real data); GCP and OCI return structured \"not yet supported\" envelopes pending their billing integrations."
+}
+
+func (s *FocusReportSkill) InputSchema() any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"providers": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Subset of providers to include. Defaults to [\"aws\",\"gcp\",\"oci\"].",
+			},
+			"period": map[string]any{
+				"type":        "string",
+				"enum":        []string{periodCurrentMonth, periodLast30Days, periodLastMonth},
+				"description": "Billing window. Defaults to current_month.",
+			},
+		},
+	}
+}
+
+func (s *FocusReportSkill) Execute(ctx context.Context, input map[string]any) (any, error) {
+	providers := extractProviderList(input)
+	period := extractPeriod(input)
+
+	report := cost.FocusReport{
+		Currency:  "USD",
+		Period:    period,
+		Providers: make([]cost.ProviderReport, 0, len(providers)),
+	}
+
+	for _, name := range providers {
+		switch strings.ToLower(strings.TrimSpace(name)) {
+		case "aws":
+			report.Providers = append(report.Providers, s.fetchAWS(ctx, period))
+		case "gcp":
+			report.Providers = append(report.Providers, notSupported("gcp",
+				"GCP Cloud Billing API integration not yet wired",
+				"https://github.com/marciozampiron/multix/issues/46#gcp"))
+		case "oci":
+			report.Providers = append(report.Providers, notSupported("oci",
+				"OCI Usage API integration not yet wired",
+				"https://github.com/marciozampiron/multix/issues/46#oci"))
+		default:
+			report.Providers = append(report.Providers, notSupported(name,
+				"unknown provider", ""))
+		}
+	}
+
+	for _, p := range report.Providers {
+		report.GrandTotal += p.ProviderTotal
+	}
+
+	return report, nil
+}
+
+func (s *FocusReportSkill) fetchAWS(ctx context.Context, period string) cost.ProviderReport {
+	rows, err := s.awsCostFetchFunc(ctx, period)
+	if err != nil {
+		return cost.ProviderReport{
+			Provider:  "aws",
+			Supported: true,
+			Reason:    fmt.Sprintf("Cost Explorer call failed: %v", err),
+		}
+	}
+	pr := cost.ProviderReport{
+		Provider:  "aws",
+		Supported: true,
+		Rows:      rows,
+	}
+	for _, r := range rows {
+		pr.ProviderTotal += r.BilledCost
+	}
+	return pr
+}
+
+func notSupported(provider, reason, trackedUnder string) cost.ProviderReport {
+	return cost.ProviderReport{
+		Provider:     provider,
+		Supported:    false,
+		Reason:       reason,
+		TrackedUnder: trackedUnder,
+	}
+}
+
+func (s *FocusReportSkill) defaultAWSCostFetch(ctx context.Context, period string) ([]cost.FocusBillingRow, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+	client := costexplorer.NewFromConfig(cfg)
+
+	start, end, err := resolvePeriod(period, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := client.GetCostAndUsage(ctx, &costexplorer.GetCostAndUsageInput{
+		TimePeriod: &cetypes.DateInterval{
+			Start: aws.String(start.Format("2006-01-02")),
+			End:   aws.String(end.Format("2006-01-02")),
+		},
+		Granularity: cetypes.GranularityMonthly,
+		Metrics:     []string{"UnblendedCost"},
+		GroupBy: []cetypes.GroupDefinition{
+			{Type: cetypes.GroupDefinitionTypeDimension, Key: aws.String("SERVICE")},
+			{Type: cetypes.GroupDefinitionTypeDimension, Key: aws.String("REGION")},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Cost Explorer GetCostAndUsage failed; ensure ce:GetCostAndUsage is allowed: %w", err)
+	}
+
+	return mapCostExplorerToFocus(out), nil
+}
+
+func mapCostExplorerToFocus(out *costexplorer.GetCostAndUsageOutput) []cost.FocusBillingRow {
+	if out == nil {
+		return nil
+	}
+	var rows []cost.FocusBillingRow
+	for _, period := range out.ResultsByTime {
+		billingPeriod := ""
+		if period.TimePeriod != nil && period.TimePeriod.Start != nil && len(*period.TimePeriod.Start) >= 7 {
+			billingPeriod = (*period.TimePeriod.Start)[:7]
+		}
+		for _, g := range period.Groups {
+			if len(g.Keys) < 2 {
+				continue
+			}
+			service, region := g.Keys[0], g.Keys[1]
+			amount := 0.0
+			if metric, ok := g.Metrics["UnblendedCost"]; ok && metric.Amount != nil {
+				if v, err := strconv.ParseFloat(*metric.Amount, 64); err == nil {
+					amount = v
+				}
+			}
+			if amount == 0 {
+				continue
+			}
+			rows = append(rows, cost.FocusBillingRow{
+				BilledCost:       amount,
+				BillingPeriod:    billingPeriod,
+				ProviderName:     "AWS",
+				ChargeType:       "Usage",
+				ResourceCategory: categorizeAWSService(service),
+				ServiceName:      service,
+				Region:           region,
+			})
+		}
+	}
+	return rows
+}
+
+// categorizeAWSService maps the most common AWS service identifiers to
+// FOCUS resource categories. Unknown services fall through as "Other".
+func categorizeAWSService(service string) string {
+	s := strings.ToLower(service)
+	switch {
+	case strings.Contains(s, "ec2") || strings.Contains(s, "elastic compute") ||
+		strings.Contains(s, "lambda") || strings.Contains(s, "fargate") ||
+		strings.Contains(s, "ecs") || strings.Contains(s, "eks"):
+		return "Compute"
+	case strings.Contains(s, "s3") || strings.Contains(s, "ebs") ||
+		strings.Contains(s, "efs") || strings.Contains(s, "glacier") ||
+		strings.Contains(s, "storage"):
+		return "Storage"
+	case strings.Contains(s, "vpc") || strings.Contains(s, "cloudfront") ||
+		strings.Contains(s, "route 53") || strings.Contains(s, "data transfer"):
+		return "Network"
+	default:
+		return "Other"
+	}
+}
+
+// resolvePeriod converts the input period token into start/end times in the
+// half-open interval Cost Explorer expects: [start, end).
+func resolvePeriod(period string, now time.Time) (time.Time, time.Time, error) {
+	year, month, _ := now.Date()
+	switch period {
+	case periodCurrentMonth, "":
+		start := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+		end := now.AddDate(0, 0, 1) // up to tomorrow so today's data is included
+		return start, end, nil
+	case periodLast30Days:
+		end := now.AddDate(0, 0, 1)
+		start := end.AddDate(0, 0, -30)
+		return start, end, nil
+	case periodLastMonth:
+		startOfThisMonth := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+		end := startOfThisMonth
+		start := end.AddDate(0, -1, 0)
+		return start, end, nil
+	default:
+		return time.Time{}, time.Time{}, fmt.Errorf("unsupported period %q", period)
+	}
+}
+
+func extractProviderList(input map[string]any) []string {
+	defaults := []string{"aws", "gcp", "oci"}
+	raw, ok := input["providers"]
+	if !ok || raw == nil {
+		return defaults
+	}
+	arr, ok := raw.([]any)
+	if !ok || len(arr) == 0 {
+		return defaults
+	}
+	out := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return defaults
+	}
+	return out
+}
+
+func extractPeriod(input map[string]any) string {
+	if v, ok := input["period"].(string); ok && v != "" {
+		return v
+	}
+	return periodCurrentMonth
+}

--- a/internal/application/cost/focus_report_skill_test.go
+++ b/internal/application/cost/focus_report_skill_test.go
@@ -1,0 +1,192 @@
+// File: internal/application/cost/focus_report_skill_test.go
+// Purpose: Unit tests for cost.focus_report — AWS happy path, GCP/OCI not_supported envelopes,
+// Cost Explorer mapping, period resolution, and Cost Explorer error propagation.
+
+package cost
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"multix/internal/domain/cost"
+	"multix/internal/ports/outbound"
+)
+
+type stubRegistry struct{}
+
+func (stubRegistry) GetCloudAuthProvider(string) (outbound.AuthProvider, error) {
+	return nil, errors.New("unused")
+}
+func (stubRegistry) GetCloudInventoryProvider(string) (outbound.InventoryProvider, error) {
+	return nil, errors.New("unused")
+}
+func (stubRegistry) GetKubernetesProvider(string) (outbound.K8sProvider, error) {
+	return nil, errors.New("unused")
+}
+func (stubRegistry) GetAIProvider(string) (outbound.AIProvider, error) {
+	return nil, errors.New("unused")
+}
+
+func newSkillWithFakeAWS(rows []cost.FocusBillingRow, awsErr error) *FocusReportSkill {
+	s := NewFocusReportSkill(stubRegistry{}).(*FocusReportSkill)
+	s.awsCostFetchFunc = func(ctx context.Context, period string) ([]cost.FocusBillingRow, error) {
+		return rows, awsErr
+	}
+	return s
+}
+
+func TestFocusReport_AWSHappyPath(t *testing.T) {
+	rows := []cost.FocusBillingRow{
+		{BilledCost: 100, BillingPeriod: "2026-05", ProviderName: "AWS", ChargeType: "Usage", ResourceCategory: "Compute", ServiceName: "AmazonEC2", Region: "us-east-1"},
+		{BilledCost: 25, BillingPeriod: "2026-05", ProviderName: "AWS", ChargeType: "Usage", ResourceCategory: "Storage", ServiceName: "AmazonS3", Region: "us-east-1"},
+	}
+	s := newSkillWithFakeAWS(rows, nil)
+
+	out, err := s.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	report := out.(cost.FocusReport)
+	if report.GrandTotal != 125 {
+		t.Fatalf("expected GrandTotal=125, got %v", report.GrandTotal)
+	}
+	if len(report.Providers) != 1 || !report.Providers[0].Supported || report.Providers[0].ProviderTotal != 125 {
+		t.Fatalf("unexpected aws provider report: %+v", report.Providers[0])
+	}
+}
+
+func TestFocusReport_GCPAndOCIReturnNotSupported(t *testing.T) {
+	s := newSkillWithFakeAWS(nil, nil)
+
+	out, err := s.Execute(context.Background(), map[string]any{"providers": []any{"gcp", "oci"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	report := out.(cost.FocusReport)
+	if len(report.Providers) != 2 {
+		t.Fatalf("expected 2 provider reports, got %d", len(report.Providers))
+	}
+	for _, p := range report.Providers {
+		if p.Supported {
+			t.Errorf("provider %s must be unsupported in v1, got Supported=true", p.Provider)
+		}
+		if p.Reason == "" || p.TrackedUnder == "" {
+			t.Errorf("provider %s missing reason/tracked_under: %+v", p.Provider, p)
+		}
+	}
+	if report.GrandTotal != 0 {
+		t.Fatalf("GrandTotal should be 0 when only unsupported providers requested, got %v", report.GrandTotal)
+	}
+}
+
+func TestFocusReport_AWSError(t *testing.T) {
+	s := newSkillWithFakeAWS(nil, errors.New("AccessDenied: ce:GetCostAndUsage not allowed"))
+
+	out, _ := s.Execute(context.Background(), map[string]any{"providers": []any{"aws"}})
+	report := out.(cost.FocusReport)
+	aws := report.Providers[0]
+	if !aws.Supported {
+		t.Fatal("aws.Supported should remain true on transient API errors")
+	}
+	if aws.Reason == "" {
+		t.Fatal("aws report should expose the Cost Explorer error message")
+	}
+	if len(aws.Rows) != 0 {
+		t.Fatalf("expected zero rows on error, got %d", len(aws.Rows))
+	}
+}
+
+func TestFocusReport_DefaultProvidersAndPeriod(t *testing.T) {
+	s := newSkillWithFakeAWS(nil, nil)
+	out, _ := s.Execute(context.Background(), map[string]any{})
+	report := out.(cost.FocusReport)
+
+	if report.Period != "current_month" {
+		t.Errorf("expected default period current_month, got %q", report.Period)
+	}
+	if len(report.Providers) != 3 {
+		t.Errorf("expected default 3 providers, got %d", len(report.Providers))
+	}
+	got := []string{}
+	for _, p := range report.Providers {
+		got = append(got, p.Provider)
+	}
+	want := []string{"aws", "gcp", "oci"}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("provider[%d] = %q; want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestFocusReport_UnknownProviderFlagged(t *testing.T) {
+	s := newSkillWithFakeAWS(nil, nil)
+	out, _ := s.Execute(context.Background(), map[string]any{"providers": []any{"alibaba"}})
+	report := out.(cost.FocusReport)
+	if len(report.Providers) != 1 || report.Providers[0].Supported || report.Providers[0].Reason != "unknown provider" {
+		t.Fatalf("unexpected report for unknown provider: %+v", report.Providers)
+	}
+}
+
+func TestCategorizeAWSService(t *testing.T) {
+	cases := map[string]string{
+		"Amazon Elastic Compute Cloud - Compute": "Compute",
+		"Amazon Simple Storage Service":          "Storage",
+		"Amazon CloudFront":                      "Network",
+		"AWS Lambda":                             "Compute",
+		"Amazon EBS":                             "Storage",
+		"AWS Data Transfer":                      "Network",
+		"Amazon Quantum Ledger":                  "Other",
+	}
+	for input, want := range cases {
+		if got := categorizeAWSService(input); got != want {
+			t.Errorf("categorizeAWSService(%q) = %q; want %q", input, got, want)
+		}
+	}
+}
+
+func TestResolvePeriod(t *testing.T) {
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+
+	t.Run("current_month", func(t *testing.T) {
+		start, end, err := resolvePeriod("current_month", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if start.Format("2006-01-02") != "2026-05-01" {
+			t.Errorf("start = %s", start)
+		}
+		// end should include today (so >= 2026-05-16)
+		if !end.After(now) {
+			t.Errorf("end %s should be after now %s", end, now)
+		}
+	})
+
+	t.Run("last_month", func(t *testing.T) {
+		start, end, err := resolvePeriod("last_month", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if start.Format("2006-01-02") != "2026-04-01" || end.Format("2006-01-02") != "2026-05-01" {
+			t.Errorf("expected 2026-04-01..2026-05-01, got %s..%s", start, end)
+		}
+	})
+
+	t.Run("last_30_days", func(t *testing.T) {
+		_, end, err := resolvePeriod("last_30_days", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !end.After(now) {
+			t.Errorf("end should be in the future relative to now")
+		}
+	})
+
+	t.Run("unsupported", func(t *testing.T) {
+		if _, _, err := resolvePeriod("ytd", now); err == nil {
+			t.Error("expected error for unsupported period")
+		}
+	})
+}

--- a/internal/application/cost/quick_scan_skill.go
+++ b/internal/application/cost/quick_scan_skill.go
@@ -63,9 +63,9 @@ func (s *QuickScanSkill) Execute(ctx context.Context, input map[string]any) (any
 		report = append(report, entry)
 	}
 	return map[string]any{
-		"note":             "resource-count proxy; not a billing query (see #46 for cost.focus_report)",
-		"grand_total":      grandTotal,
-		"providers":        report,
+		"note":        "resource-count proxy; not a billing query (see #46 for cost.focus_report)",
+		"grand_total": grandTotal,
+		"providers":   report,
 	}, nil
 }
 

--- a/internal/application/doctor/auth_skill_test.go
+++ b/internal/application/doctor/auth_skill_test.go
@@ -28,10 +28,10 @@ func (f *fakeAuthProvider) Validate(ctx context.Context) (*auth.ValidationResult
 }
 
 type fakeRegistry struct {
-	auth     map[string]*fakeAuthProvider
-	authErr  map[string]error
-	k8s      map[string]outbound.K8sProvider
-	k8sErr   map[string]error
+	auth    map[string]*fakeAuthProvider
+	authErr map[string]error
+	k8s     map[string]outbound.K8sProvider
+	k8sErr  map[string]error
 }
 
 func (f *fakeRegistry) GetCloudAuthProvider(name string) (outbound.AuthProvider, error) {

--- a/internal/application/doctor/k8s_skill_test.go
+++ b/internal/application/doctor/k8s_skill_test.go
@@ -60,10 +60,10 @@ func TestK8sHealthSkill_ProviderError(t *testing.T) {
 
 func TestIsHealthyClusterStatus(t *testing.T) {
 	cases := map[string]bool{
-		"ACTIVE":  true,
-		"RUNNING": true,
-		"running": true,
-		" Active": true,
+		"ACTIVE":   true,
+		"RUNNING":  true,
+		"running":  true,
+		" Active":  true,
 		"CREATING": false,
 		"DELETING": false,
 		"":         false,

--- a/internal/application/landingzone/audit_skill_test.go
+++ b/internal/application/landingzone/audit_skill_test.go
@@ -16,7 +16,7 @@ type fakeAuth struct {
 	err    error
 }
 
-func (f *fakeAuth) ID() string                                                 { return "" }
+func (f *fakeAuth) ID() string { return "" }
 func (f *fakeAuth) Login(ctx context.Context, c auth.Credentials) (*auth.Session, error) {
 	return nil, nil
 }

--- a/internal/application/security/identity_posture_skill_test.go
+++ b/internal/application/security/identity_posture_skill_test.go
@@ -15,7 +15,7 @@ type fakeAuth struct {
 	err      error
 }
 
-func (f *fakeAuth) ID() string                                                 { return "" }
+func (f *fakeAuth) ID() string { return "" }
 func (f *fakeAuth) Login(ctx context.Context, c auth.Credentials) (*auth.Session, error) {
 	return nil, nil
 }

--- a/internal/bootstrap/skills.go
+++ b/internal/bootstrap/skills.go
@@ -36,8 +36,9 @@ func BuildSkillRegistry(providers outbound.ProviderRegistry) *skills.Registry {
 	// Security posture.
 	skillRegistry.Register(security.NewIdentityPostureSkill(providers))
 
-	// Cost (quick proxy; full FOCUS report is #46).
+	// Cost: quick_scan is a resource-count proxy; focus_report is FOCUS-aligned billing.
 	skillRegistry.Register(cost.NewQuickScanSkill(providers))
+	skillRegistry.Register(cost.NewFocusReportSkill(providers))
 
 	// Authentication and identity.
 	skillRegistry.Register(auth.NewLoginSkill(providers))

--- a/internal/domain/cost/focus.go
+++ b/internal/domain/cost/focus.go
@@ -40,8 +40,8 @@ type ProviderReport struct {
 
 // FocusReport is the top-level payload of cost.focus_report.
 type FocusReport struct {
-	Currency  string           `json:"currency"`
-	Period    string           `json:"period"`
-	Providers []ProviderReport `json:"providers"`
-	GrandTotal float64         `json:"grand_total"`
+	Currency   string           `json:"currency"`
+	Period     string           `json:"period"`
+	Providers  []ProviderReport `json:"providers"`
+	GrandTotal float64          `json:"grand_total"`
 }

--- a/internal/domain/cost/focus.go
+++ b/internal/domain/cost/focus.go
@@ -1,0 +1,47 @@
+// File: internal/domain/cost/focus.go
+// Company: Hassan
+// Creator: Zamp
+// Created: 02/05/2026
+// Updated: 02/05/2026
+// Purpose: Domain types for FOCUS-aligned billing reports consumed by cost.focus_report.
+
+// Package cost defines provider-agnostic billing types aligned with the
+// FinOps Open Cost & Usage Specification (FOCUS) v1.0.
+package cost
+
+// FocusBillingRow is a single line item in a FOCUS-shaped billing report.
+//
+// Field tags follow the FOCUS PascalCase convention so the JSON wire format
+// matches consumers that already speak FOCUS (BigQuery exports, FinOps Hub,
+// CloudHealth FOCUS export, etc.). The Go field names follow Go's idiomatic
+// camelCase and are exported.
+type FocusBillingRow struct {
+	BilledCost       float64 `json:"BilledCost"`
+	BillingPeriod    string  `json:"BillingPeriod"`    // YYYY-MM
+	ProviderName     string  `json:"ProviderName"`     // "AWS" | "GCP" | "OCI"
+	ChargeType       string  `json:"ChargeType"`       // "Usage" | "Tax" | "Purchase" | "Credit"
+	ResourceCategory string  `json:"ResourceCategory"` // "Compute" | "Storage" | "Network" | "Other"
+	ServiceName      string  `json:"ServiceName"`      // raw provider service ID (e.g. "AmazonEC2")
+	Region           string  `json:"Region"`
+}
+
+// ProviderReport bundles per-provider billing rows with explicit support metadata.
+// Providers that have no native integration yet return Supported=false plus a
+// reason and tracking issue, so agents can distinguish "no spend" from
+// "not yet implemented".
+type ProviderReport struct {
+	Provider      string            `json:"provider"`
+	Supported     bool              `json:"supported"`
+	Reason        string            `json:"reason,omitempty"`
+	TrackedUnder  string            `json:"tracked_under,omitempty"`
+	Rows          []FocusBillingRow `json:"rows,omitempty"`
+	ProviderTotal float64           `json:"provider_total,omitempty"`
+}
+
+// FocusReport is the top-level payload of cost.focus_report.
+type FocusReport struct {
+	Currency  string           `json:"currency"`
+	Period    string           `json:"period"`
+	Providers []ProviderReport `json:"providers"`
+	GrandTotal float64         `json:"grand_total"`
+}


### PR DESCRIPTION
## Summary
Reimplementation of the `cost.focus_report` skill — replacement for the closed PR #60.

The old PR returned hardcoded `1250.50` and `850.75` mock numbers as if they were real billing data, which would mislead any LLM consuming the result. This rewrite is honest about partial coverage:

- **AWS** — real `GetCostAndUsage` against Cost Explorer, grouped by `SERVICE` and `REGION`, monthly granularity. Mapped into FOCUS rows with derived `ResourceCategory` (Compute/Storage/Network/Other).
- **GCP** — structured `{supported: false, reason, tracked_under}` envelope. Cloud Billing BigQuery export integration is a follow-up.
- **OCI** — same envelope until the Usage API is wired.

The agent can distinguish "no spend" from "not yet implemented" because every entry carries an explicit `Supported` flag.

## Key differences vs. closed PR #60

| Aspect | PR #60 (closed) | This PR |
|---|---|---|
| AWS billing | Hardcoded `1250.50` mock | Real Cost Explorer call |
| GCP billing | Hardcoded `850.75` mock | Structured `not_supported` |
| OCI billing | Silently empty | Structured `not_supported` |
| Input shape | `provider` (string enum) | `providers[]` (matches `cost.quick_scan`) |
| Tests | None | 10 unit tests |
| `build/multix` binary | 75 MB committed | Not committed |
| Stub disclosure | Hidden in description | Explicit `Supported` field |

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./... -count=1` — all green (14 packages)
- [x] `make test-race` — race-clean
- [x] 10 unit tests: AWS happy path, AWS Cost Explorer error, GCP/OCI not_supported, default providers/period, unknown provider, AWS service categorization, all 4 period branches
- [ ] Live smoke (manual, requires `ce:GetCostAndUsage` IAM permission): `curl -X POST localhost:8080/execute -d '{"skill":"cost.focus_report","params":{"providers":["aws"],"period":"current_month"}}'`

## Follow-ups (do not block this PR)
- `#46-gcp` — wire Cloud Billing BigQuery export ingestion
- `#46-oci` — wire OCI Usage API
- Consider adding `chargeType` filter param once first follow-up lands

Refs #46