### PR TITLE
docs: refresh runtime documentation and testing playbook

### DIFF
--- a/.agent/COMMANDS.md
+++ b/.agent/COMMANDS.md
@@ -5,15 +5,15 @@
 Always prefer the repository Makefile over ad-hoc shell commands.
 
 Primary commands:
+- `make all`
 - `make build`
+- `make build-cross`
 - `make run`
 - `make test`
 - `make test-race`
 - `make fmt`
 - `make vet`
-- `make vuln`
 - `make tidy`
-- `make lint`
 
 ---
 
@@ -23,18 +23,20 @@ Typical safe workflow:
 1. inspect current files
 2. make focused changes
 3. run:
-   - `make fmt`
-   - `make vet`
-   - `make test`
-4. if dependency changes:
-   - `make tidy`
-5. if security-sensitive:
-   - `make vuln`
+   - `go test ./...`
+   - `go vet ./...`
+   - `make all`
+   - `make build-cross`
+   - `git diff --check`
+4. if touching runtime, registry, adapters, or shared state:
+   - `make test-race`
+5. clean generated build artifacts unless they are part of the requested change
 6. commit changes on a focused branch
 7. open a GitHub pull request before considering the activity delivered
 
 See also:
 - `.agent/PULL_REQUESTS.md`
+- `docs/testing-playbook.md`
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,7 +24,7 @@ This repository must remain:
 Multix is not just a CLI.
 It is a **platform of reusable capabilities ("skills")** that can be consumed by:
 - CLI commands
-- future API endpoints
+- local HTTP runtime endpoints
 - future AI agents / tool-calling
 - future MCP-compatible adapters
 
@@ -161,13 +161,21 @@ Naming convention:
 
 Examples:
 - `doctor.run`
+- `doctor.auth`
+- `doctor.k8s`
 - `auth.validate`
 - `auth.whoami`
 - `inventory.scan`
 - `inventory.summary`
 - `k8s.list_clusters`
 - `ai.explain`
-- `ai.generate_terraform`
+- `cost.quick_scan`
+- `cost.focus_report`
+- `infra.generate_network`
+- `landingzone.audit`
+- `security.identity_posture`
+- `security.k8s_audit`
+- `security.iam_audit`
 
 ---
 
@@ -197,6 +205,7 @@ When asked to improve comments or documentation in the repository:
 - do not rename packages or symbols
 - do not move files
 - do not introduce new abstractions
+- keep README, `docs/README.md`, `docs/skills/catalog.md`, and `docs/testing-playbook.md` consistent when public behavior changes
 
 Documentation-only changes may include:
 - file headers in important Go files

--- a/README.md
+++ b/README.md
@@ -122,25 +122,281 @@ make test-race
 git diff --check
 ```
 
-## 7. Current CLI Usage
+## 7. Command Reference
 
-Common global flags:
-- `--provider`
-- `--output [json|table]`
+Build once before running local examples:
 
-Provider values currently vary by skill:
-- Cloud providers: `aws`, `gcp`, `oci`
-- AI-specific provider values: `gemini`
+```bash
+make build
+```
 
-Real, validated auth commands:
+Global flags:
+
+- `--provider`, `-p`: target provider. Default: `aws`.
+- `--output`, `-o`: output format. Supported values: `json`, `table`.
+- `--log-level`, `-l`: log level. Supported values: `debug`, `info`, `warn`, `error`.
+
+Provider values:
+
+- Cloud providers: `aws`, `gcp`, `oci`.
+- AI provider: `gemini` is used by `ai.explain`.
+
+### Version
+
+```bash
+./build/multix version
+```
+
+Prints the current CLI version compiled into the binary.
+
+### Doctor
+
+```bash
+./build/multix doctor
+```
+
+Runs local readiness checks for tools and dependencies through the `doctor.run` skill.
+
+Runtime-only related skills:
+
+- `doctor.auth`: provider auth health summary.
+- `doctor.k8s`: managed Kubernetes health summary.
+
+Use them through `/execute`:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"doctor.auth","params":{"providers":["aws","gcp","oci"]}}'
+```
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"doctor.k8s","params":{"providers":["aws","gcp","oci"]}}'
+```
+
+### Auth
 
 ```bash
 ./build/multix auth validate --provider aws --output json
-./build/multix auth whoami --provider aws --output table
 ./build/multix auth validate --provider gcp --output json
+./build/multix auth validate --provider oci --output json
+```
+
+Validates credentials for the selected provider through `auth.validate`.
+
+```bash
+./build/multix auth whoami --provider aws --output table
 ./build/multix auth whoami --provider gcp --output table
+./build/multix auth whoami --provider oci --output json
+```
+
+Displays the active identity for the selected provider through `auth.whoami`.
+
+Runtime-only related skill:
+
+- `auth.login`: login-oriented skill exposed through the registry.
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"auth.login","provider":"aws","params":{}}'
+```
+
+### Inventory
+
+```bash
+./build/multix inventory list --provider aws --service compute --output json
+./build/multix inventory list --provider aws --service storage --output table
+./build/multix inventory list --provider gcp --service compute --output json
+./build/multix inventory list --provider gcp --service storage --output json
 ./build/multix inventory list --provider oci --service compute --output json
-./build/multix k8s clusters --provider aws --output json
+./build/multix inventory list --provider oci --service storage --output json
+```
+
+Runs `inventory.scan` for a provider and optional service/resource type.
+
+Runtime-only related skill:
+
+- `inventory.summary`: provider inventory summary.
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"inventory.summary","params":{"provider":"aws"}}'
+```
+
+### Kubernetes
+
+```bash
+./build/multix k8s clusters --provider aws
+./build/multix k8s clusters --provider gcp
+./build/multix k8s clusters --provider oci
+```
+
+Lists managed clusters through `k8s.list_clusters`. The current CLI renderer prints a compact table-style line per cluster.
+
+### AI
+
+```bash
+./build/multix ai explain "Explain this IAM finding" --output json
+```
+
+Runs `ai.explain` using the Gemini provider path.
+
+### Runtime Server
+
+```bash
+./build/multix serve --port 8080
+```
+
+Starts the local HTTP runtime for agents and automation.
+
+Endpoints:
+
+```bash
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/tools
+curl -s http://localhost:8080/capabilities
+curl -s http://localhost:8080/metrics
+```
+
+Execute any registered skill:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -H "X-Request-ID: manual-test-001" \
+  -d '{
+    "skill": "auth.validate",
+    "provider": "aws",
+    "params": {}
+  }'
+```
+
+### Cost And FinOps
+
+`cost.quick_scan` is a fast resource-count proxy:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "cost.quick_scan",
+    "params": {
+      "providers": ["aws", "gcp", "oci"]
+    }
+  }'
+```
+
+`cost.focus_report` returns FOCUS-aligned billing rows:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "cost.focus_report",
+    "params": {
+      "providers": ["aws", "gcp", "oci"],
+      "period": "current_month"
+    }
+  }'
+```
+
+Provider prerequisites:
+
+- AWS: Cost Explorer permission for `ce:GetCostAndUsage`.
+- GCP: `MULTIX_GCP_BILLING_DATASET=<project>.<dataset>.<table>` and BigQuery billing export access.
+- OCI: `MULTIX_OCI_TENANCY_OCID=<tenancy_ocid>` and Usage API access.
+
+Supported periods:
+
+- `current_month`
+- `last_30_days`
+- `last_month`
+
+### Landing Zone
+
+`landingzone.audit` is exposed through the runtime:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "landingzone.audit",
+    "params": {
+      "providers": ["aws", "gcp", "oci"]
+    }
+  }'
+```
+
+### Security
+
+Identity posture:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "security.identity_posture",
+    "params": {
+      "providers": ["aws", "gcp", "oci"]
+    }
+  }'
+```
+
+Kubernetes audit:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "security.k8s_audit",
+    "params": {
+      "providers": ["aws", "gcp", "oci"],
+      "ai_provider": "gemini"
+    }
+  }'
+```
+
+IAM audit:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "security.iam_audit",
+    "params": {
+      "providers": ["aws", "gcp", "oci"],
+      "ai_provider": "gemini"
+    }
+  }'
+```
+
+### Infrastructure Generation
+
+`infra.generate_network` generates a network topology proposal through the AI provider:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "infra.generate_network",
+    "params": {
+      "provider": "aws",
+      "ai_provider": "gemini",
+      "intent": "three-tier web application with public, private, and database subnets",
+      "region": "us-east-1",
+      "cidr": "10.0.0.0/16"
+    }
+  }'
+```
+
+Use `GET /tools` to inspect the exact input schema for every registered skill:
+
+```bash
+curl -s http://localhost:8080/tools
 ```
 
 ## 8. Local Auth Troubleshooting

--- a/README.md
+++ b/README.md
@@ -11,31 +11,30 @@ Enterprise-grade multi-cloud operations for humans, command-line workflows, and 
 MULTIX is not just a CLI. It is a reusable execution runtime for operational skills that can be invoked consistently across multiple surfaces:
 - CLI commands
 - AI agents and function-calling adapters
-- Future local runtime endpoints (`multix serve`)
-- Future APIs and automation layers
+- Local runtime endpoints (`multix serve`)
+- Future MCP/plugin integrations
 
 Core principle:
 > **Agent thinks and orchestrates. Skill executes.**
 
 **Implemented and validated today:**
-- Go project with Cobra CLI
+- Go project with Cobra CLI and local HTTP runtime
 - Skills-first architecture and universal skill contract
-- Skill registry and skill executor
+- Stable v1.0 contract docs for skills and provider ports
+- Skill registry, skill executor, and dynamic tool manifests
 - Provider registry with normalized provider names
-- Agent tool adapter and tool manifest generation
-- Real AWS auth skills: `auth.validate`, `auth.whoami`
-- Real GCP auth skills: `auth.validate`, `auth.whoami`
-- GCP whoami enrichment: ADC first, env fallback, optional local `gcloud` enrichment
-- Tests, build, vet, and fmt passing locally
+- Runtime endpoints for health, tools, capabilities, metrics, and execution
+- Structured request IDs propagated through runtime execution
+- Real AWS and GCP auth skills; OCI auth adapter support
+- Inventory skills for AWS, GCP, and OCI adapters/stubs
+- Kubernetes discovery through `k8s.list_clusters`
+- FOCUS-aligned `cost.focus_report` with AWS Cost Explorer, GCP BigQuery billing export, and OCI Usage API
+- AI-assisted skills for network generation, Kubernetes audit, and IAM audit
+- CI and local validation gates for fmt, tests, vet, build, cross-build, and race tests
 
-**Implemented target (v0.4-alpha):**
-- OCI auth provider (preview)
-- `multix serve` local runtime
-- Capability matrix endpoint
-- Agent runtime endpoints (health, manifests, tool execution)
-
-**Planned / next target (v0.5-alpha):**
-- Inventory real providers for AWS, GCP, OCI
+**Still open:**
+- Issue #20: implementation of the plugin extension model proposed in ADR 0008.
+- Future MCP server/client surfaces for federated plugins.
 
 ## 3. Architectural Philosophy
 
@@ -47,7 +46,16 @@ Examples of skills (some implemented, some foundational/planned):
 - `inventory.scan`
 - `inventory.summary`
 - `k8s.list_clusters`
+- `doctor.auth`
+- `doctor.k8s`
 - `ai.explain`
+- `cost.quick_scan`
+- `cost.focus_report`
+- `infra.generate_network`
+- `landingzone.audit`
+- `security.identity_posture`
+- `security.k8s_audit`
+- `security.iam_audit`
 
 The CLI is only one surface. Skills are the product.
 
@@ -61,7 +69,7 @@ Skills implement a JSON-capable contract and can be executed consistently across
 
 **Register once. Expose everywhere.**
 
-## Runtime (v0.4-alpha)
+## Runtime
 
 `multix serve` exposes the local HTTP runtime
 
@@ -70,10 +78,12 @@ Runtime endpoints:
 - `GET /tools`
 - `POST /execute`
 - `GET /capabilities`
+- `GET /metrics`
 
 Links:
 - [docs/runtime-architecture.md](docs/runtime-architecture.md)
 - [docs/quickstart-agent-runtime.md](docs/quickstart-agent-runtime.md)
+- [docs/testing-playbook.md](docs/testing-playbook.md)
 
 ## 5. Project Layout
 
@@ -95,12 +105,21 @@ multix/
 
 ## 6. Quick Start
 
-**Prerequisites:** Go 1.25+
+**Prerequisites:** Go 1.25+ or the version declared in `go.mod`.
 
 ```bash
 go mod tidy
 make build
 ./build/multix version
+```
+
+Full local gate:
+
+```bash
+make all
+make build-cross
+make test-race
+git diff --check
 ```
 
 ## 7. Current CLI Usage
@@ -110,7 +129,7 @@ Common global flags:
 - `--output [json|table]`
 
 Provider values currently vary by skill:
-- Cloud providers: `aws`, `gcp`
+- Cloud providers: `aws`, `gcp`, `oci`
 - AI-specific provider values: `gemini`
 
 Real, validated auth commands:
@@ -120,6 +139,8 @@ Real, validated auth commands:
 ./build/multix auth whoami --provider aws --output table
 ./build/multix auth validate --provider gcp --output json
 ./build/multix auth whoami --provider gcp --output table
+./build/multix inventory list --provider oci --service compute --output json
+./build/multix k8s clusters --provider aws --output json
 ```
 
 ## 8. Local Auth Troubleshooting
@@ -130,6 +151,7 @@ Real, validated auth commands:
 - `export AWS_REGION=us-east-1`
 - `export AWS_EC2_METADATA_DISABLED=true`
 - `export AWS_PROFILE=<profile>`
+- Cost reporting uses AWS Cost Explorer and needs permission for `ce:GetCostAndUsage`.
 
 ### GCP notes
 - `gcloud auth login` authenticates the gcloud CLI
@@ -139,6 +161,15 @@ Real, validated auth commands:
 - `gcloud auth login`
 - `gcloud auth application-default login`
 - `gcloud config set project <project-id>`
+- GCP billing reports need Cloud Billing BigQuery export and:
+- `export MULTIX_GCP_BILLING_DATASET=<project>.<dataset>.<table>`
+
+### OCI notes
+- OCI SDK credentials default to `$HOME/.oci/config` unless `OCI_CONFIG_FILE` is set
+- Recommended local setup:
+- `export OCI_CONFIG_FILE=$HOME/.oci/config`
+- `export MULTIX_OCI_TENANCY_OCID=<tenancy_ocid>`
+- Cost reporting uses the OCI Usage API and needs Cost and Usage Reports plus usage-budgets read access.
 
 ## 9. Product Evolution / Release Journey
 
@@ -169,7 +200,7 @@ Real, validated auth commands:
 - Local auth troubleshooting docs
 - Real local smoke validation
 
-### v0.4-alpha — OCI Auth + Agent Runtime (`multix serve`)
+### v0.4 — OCI Auth + Agent Runtime (`multix serve`)
 - OCI auth provider (preview)
 - `multix serve`
 - Health endpoint
@@ -180,35 +211,39 @@ Real, validated auth commands:
 
 ## 10. Forward Roadmap
 
-### v0.5-alpha — Real Inventory
+### v0.5 — Real Inventory
 - AWS: EC2 + S3
 - GCP: Compute + Cloud Storage
 - OCI: Compute + Object Storage
+Status: delivered through provider adapters/stubs and registry wiring.
 
 ### v0.6-alpha — Kubernetes Real Integrations
 - EKS
 - GKE
 - OKE
+Status: delivered for managed cluster listing paths.
 
 ### v0.7-alpha — Golden Paths / Operational Skills
 - `doctor.auth`
 - `doctor.k8s`
-- `k8s.cluster-health`
+- `doctor.run`
 - `landingzone.audit`
-- `security.identity-posture`
-- `cost.quick-scan`
+- `security.identity_posture`
+- `cost.quick_scan`
+Status: delivered.
 
 ### v0.8-alpha — AI-Assisted Provisioning & Scaffolding
 - `infra.generate_network` (VPC/VCN via AI Tooling)
-- `diagram.generate`
+Status: delivered for `infra.generate_network`.
 
 ### v0.9-alpha — FinOps Unified Billing (FOCUS)
 - `cost.focus_report` (Multi-cloud billing aggregation)
-- `cost.pricing_query` (Real-time public cloud pricing lookup)
+Status: delivered for AWS Cost Explorer, GCP Cloud Billing BigQuery export, and OCI Usage API.
 
 ### v0.10-alpha — AI-Assisted Security Remediation
 - `security.k8s_audit` (CVE Scanner & AI Remediation)
 - `security.iam_audit` (Multi-cloud IAM least-privilege analysis & AI Remediation)
+Status: delivered.
 
 ### v1.0.0-beta — Enterprise Hardening
 - Stable provider contracts
@@ -216,6 +251,7 @@ Real, validated auth commands:
 - Hardened runtime
 - Plugin story / extension model
 - Enterprise docs + skill catalog
+Status: contracts and ADRs delivered; plugin implementation remains tracked under issue #20.
 
 ## 11. Extending the Platform
 
@@ -232,10 +268,14 @@ MULTIX is not just a multi-cloud CLI. It is becoming:
 - A universal multi-cloud skill runtime
 - A safe execution surface for AI agents
 - A foundation for enterprise operational golden paths
-- Future-ready for MCP-style tool ecosystems
+- Future-ready for MCP-style plugin ecosystems
 
 In practical terms, MULTIX is evolving from a CLI into a local execution runtime for portable, provider-aware operational skills.
 
-## 13. License
+## 13. Testing
+
+Use [docs/testing-playbook.md](docs/testing-playbook.md) as the caderno de teste for local validation, runtime smoke checks, provider checks, and release readiness.
+
+## 14. License
 
 Define your preferred license here (Apache-2.0, MIT, or internal enterprise license).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,43 @@
 # Multix Documentation
 
-Welcome to the Multix internal documentation hub. This directory contains the architectural decisions, coding standards, and templates required to contribute to the Multix Agent CLI platform.
+This directory is the documentation hub for the Multix skills-first multi-cloud runtime.
 
-## Contents
+## Start Here
 
-- **`standards/`**: Coding conventions and formatting rules.
-- **`templates/`**: Boilerplate templates for new Go files.
-- **`skills/`**: The catalog of available skills and guidelines on creating new ones.
-- **`adr/`**: Architecture Decision Records detailing our evolution.
-- **`project-historical-resolution.md`**: Audit trail for Project items that were resolved before a PR was linked.
+- `../README.md`: product overview, quick start, runtime endpoints, provider notes.
+- `quickstart-agent-runtime.md`: hands-on guide for `multix serve` and `/execute`.
+- `testing-playbook.md`: caderno de teste for local validation, runtime smoke tests, provider checks, and release gates.
+- `skills/catalog.md`: current registered skills and provider notes.
+- `runtime-architecture.md`: HTTP runtime architecture and endpoint contracts.
 
-Make sure to read these documents before submitting a pull request.
+## Architecture
+
+- `adr/0001-skills-first-architecture.md`
+- `adr/0002-provider-registry.md`
+- `adr/0003-agent-tool-contracts.md`
+- `adr/0004-local-http-runtime.md`
+- `adr/0005-request-id-propagation.md`
+- `adr/0006-prometheus-text-exposition.md`
+- `adr/0007-tool-manifest-shape.md`
+- `adr/0008-plugin-extension-model.md`
+
+ADR 0008 is the source of truth for the proposed plugin extension model. It is design-complete, but implementation remains tracked under issue #20.
+
+## Standards
+
+- `standards/contracts.md`: v1.0 contract promise for skills and ports.
+- `standards/coding-style.md`: Go coding conventions.
+- `standards/doc-comments.md`: comment expectations.
+- `standards/file-headers.md`: file header conventions.
+
+## Templates
+
+- `templates/go-file-template.md`
+- `skills/templates/new-skill-template.md`
+
+## Project Notes
+
+- `project-historical-resolution.md`: audit trail for Project items resolved before a PR was linked.
+- `../project/PROJECT_ROADMAP.md`: roadmap status and operating notes.
+
+Read `../CONTRIBUTING.md`, `standards/contracts.md`, and `testing-playbook.md` before opening a pull request.

--- a/docs/quickstart-agent-runtime.md
+++ b/docs/quickstart-agent-runtime.md
@@ -1,10 +1,10 @@
-# Quickstart: Using the MULTIX Agent Runtime (v0.4-alpha)
+# Quickstart: Using the MULTIX Agent Runtime
 
-This is the practical quickstart guide for local developers, shell users, AI agent builders, and LLM tool orchestrators. 
+This is the practical quickstart guide for local developers, shell users, AI agent builders, and LLM tool orchestrators.
 
 ## Prerequisites
 
-- Go 1.22+ installed on your local machine (required for `net/http` method-aware routing patterns).
+- Go 1.25+ or the version declared in `go.mod`.
 - A buildable repository structure.
 - Supported providers (`aws`, `gcp`, `oci`) depend on locally configured credentials on the host machine. (e.g., OCI examples assume a valid `~/.oci/config`).
 
@@ -50,34 +50,56 @@ Discover the generic platform capabilities and connected providers.
 curl -s http://localhost:8080/capabilities
 ```
 
+### Metrics
+Scrape Prometheus text exposition metrics.
+```bash
+curl -s http://localhost:8080/metrics
+```
+
 ## Execute a skill manually
 
-### Example A — OCI auth validate
-Validates if your Oracle credentials work end-to-end.
+### Example A - AWS auth validate
+Validates if your AWS credentials work end-to-end.
 ```bash
 curl -s -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
+  -H "X-Request-ID: quickstart-auth-aws" \
   -d '{
     "skill": "auth.validate",
-    "provider": "oci",
-    "params": {
-      "profile": "DEFAULT"
-    }
+    "provider": "aws",
+    "params": {}
   }'
 ```
 
-### Example B — OCI auth whoami
+### Example B - OCI auth whoami
 Retrieves identifying user boundaries from the OCI profile.
 ```bash
 curl -s -X POST http://localhost:8080/execute \
   -H "Content-Type: application/json" \
+  -H "X-Request-ID: quickstart-whoami-oci" \
   -d '{
     "skill": "auth.whoami",
     "provider": "oci"
   }'
 ```
 
-### Example C — unknown skill
+### Example C - cost.focus_report for unconfigured GCP
+This shows the supported-but-unconfigured envelope when Cloud Billing BigQuery export is not configured.
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -H "X-Request-ID: quickstart-cost-gcp" \
+  -d '{
+    "skill": "cost.focus_report",
+    "provider": "gcp",
+    "params": {
+      "providers": ["gcp"],
+      "period": "current_month"
+    }
+  }'
+```
+
+### Example D - unknown skill
 Displays the explicit 404 response payload when targeting a missing or hypothetical capability.
 ```bash
 curl -i -X POST http://localhost:8080/execute \
@@ -86,7 +108,7 @@ curl -i -X POST http://localhost:8080/execute \
     "skill": "non.existent.skill"
   }'
 ```
-*Expected behavior:* The HTTP response will strictly map to `404 Not Found` with the JSON `{"ok": false, "error": "skill not found"}`.
+Expected behavior: the HTTP response maps to `404 Not Found` with an error envelope.
 
 ## LLM / agent integration pattern
 
@@ -129,10 +151,10 @@ make smoke-oci
 - **OCI config missing or invalid:** The execution results in `ok: false` returning `bad configuration` or `failed to retrieve` in the JSON response payload payload.
 - **Unknown skill returns 404:** Check for typos in the `"skill": ""` parameter matching the exact dot-notation schema.
 - **Malformed JSON returns 400:** Make sure trailing commas or unquoted strings aren't polluting the JSON POST blob.
-- **Empty /tools result:** Usually denotes zero registered capabilities wired inside `internal/bootstrap/registry.go`.
+- **Empty /tools result:** Usually denotes zero registered capabilities wired inside `internal/bootstrap/skills.go`.
+- **GCP billing not configured:** Set `MULTIX_GCP_BILLING_DATASET=<project>.<dataset>.<table>`.
+- **OCI billing not configured:** Set `MULTIX_OCI_TENANCY_OCID=<tenancy_ocid>`.
 
 ## Stability note
 
-**v0.4-alpha**
-
-The current execution constraints and endpoint shapes are intentionally small and practical. The contract may evolve for distributed topologies later, but the current endpoints are considered the strict foundational reference for this milestone.
+The current local runtime endpoints are the practical reference surface for agent and tool-calling clients. The future MCP/plugin model is documented in ADR 0008 and remains implementation work under issue #20.

--- a/docs/runtime-architecture.md
+++ b/docs/runtime-architecture.md
@@ -1,6 +1,6 @@
-# MULTIX Runtime Architecture (v0.4-alpha)
+# MULTIX Runtime Architecture
 
-This is the authoritative architecture document for the local HTTP runtime adapter introduced in v0.4. The runtime exposes an agent-facing execution surface while keeping the CLI entrypoint extremely thin. It is an intentional adapter-based design kept maximally minimal for the v0.4 milestone.
+This is the authoritative architecture document for the local HTTP runtime adapter. The runtime exposes an agent-facing execution surface while keeping the CLI entrypoint thin. It is an adapter-based design built around the same skill registry used by CLI commands and generated tool manifests.
 
 ## Why this exists
 
@@ -23,6 +23,7 @@ CLI (cobra)
         -> /tools
         -> /execute
         -> /capabilities
+        -> /metrics
           -> ToolAdapter
             -> skill registry / executor
               -> provider-aware skill implementations
@@ -39,7 +40,7 @@ CLI (cobra)
 - **Graceful shutdown**: Correct signal interception prevents orphaned processes.
 - **JSON-first machine interface**: Clean serialization optimized for machine intelligibility.
 - **Local-first execution model**: Meant for local sandboxing and safe terminal contexts.
-- **Intentional Simplicity**: v0.4 intentionally avoids auth middleware, persistence, distributed runtime concerns, or plugin overengineering.
+- **Intentional Simplicity**: the runtime intentionally avoids auth middleware, persistence, distributed runtime concerns, or plugin overengineering.
 
 ## Current runtime endpoints
 
@@ -137,6 +138,14 @@ Returns the runtime capability matrix mapping enabled features and declared runt
 ```
 - **Status Codes:** `200 OK`
 
+### GET /metrics
+Returns Prometheus text exposition metrics for runtime requests.
+- **Method:** `GET`
+- **Path:** `/metrics`
+- **Purpose:** Gives local operators and CI smoke tests a scrapeable metrics surface without requiring a heavy metrics dependency.
+- **Response Shape:** Prometheus text format.
+- **Status Codes:** `200 OK`
+
 ## Runtime lifecycle
 
 To boot the engine: `multix serve --port 8080`.
@@ -144,11 +153,11 @@ The server starts logging and binds to the specified port.
 
 A critical element of the architecture is its *Graceful Shutdown* handling. Upon receiving `os.Interrupt` or `SIGTERM`, the runtime enforces a strict 5-second shutdown timeout context before forcefully terminating. This ensures that in-flight skill executions wrap up safely, which is imperative for CI workflows, containerization limits (like Docker's `STOPSIGNAL`), and future service wrappers.
 
-## Testing strategy (v0.4)
+## Testing strategy
 
 The current testing regime rigorously dictates:
 - **Unit tests for runtime handlers:** Verifying parsing and serialization of `executeRequest` and envelopes inside `server_test.go`.
-- **Endpoint coverage:** Mocks and tests assert coverage for `/health`, `/tools`, and `/execute`.
+- **Endpoint coverage:** Mocks and tests assert coverage for `/health`, `/tools`, `/metrics`, and `/execute`.
 - **404 Mapping & Provider Injection:** The exact behavior of routing unknown skills to `404` and enforcing `params["provider"]` logic is unit-tested sequentially.
 - **OCI Smoke Script for auth flows:** End-to-end execution of the binary locally via `scripts/e2e/oci_smoke.sh` hooked up by `make smoke-oci`. These smoke tests are *intentionally strict*, validating graceful failure when `~/.oci/config` is absent and demanding absolute lack of `panic` logs from Go core. They are specifically not full-blown cloud integration suites, but bulletproof deployment readiness guards.
 
@@ -158,16 +167,15 @@ The following are strictly out of scope for the current design:
 - No auth middleware or token checks on runtime endpoints.
 - No TLS termination in-process (must be handled by a proxy if exposed).
 - No OpenAPI (Swagger) spec generation for the runtime yet.
-- No request tracing / telemetry middleware yet.
-- No Prometheus metrics endpoint yet (planned later).
+- No distributed tracing middleware yet; request IDs are propagated locally.
 - No remote daemon deployment contract yet (assumes `localhost` binding).
 - No streaming execution protocol yet (WebSocket/SSE).
-- No plugin sandboxing yet (WASM/shared object isolation).
+- No plugin sandboxing yet. ADR 0008 proposes federated HTTP/MCP servers instead of native Go plugins.
 
 ## Forward path
 
-The runtime paves the exact groundwork required for broader integrations:
-- **v0.5**: Broad inventory expansion parsing EC2/S3, GCP Compute, and OCI Object Storage payloads back through the Execute path.
-- **v0.6**: Observability enhancements tracking capability invocations.
-- **v0.7**: Higher-level doctor skills (`doctor.auth`).
-- **v1.0**: Absolute contract stabilization and public plugin extension models.
+The runtime paves the groundwork required for broader integrations:
+- MCP server surface for local skills.
+- MCP client/plugin loader for external federated tools.
+- Stronger operational hardening for auth around non-local deployments.
+- Optional distributed tracing when request IDs are no longer enough.

--- a/docs/skills/catalog.md
+++ b/docs/skills/catalog.md
@@ -1,26 +1,73 @@
 # Skills Catalog
 
-## Core Platform Skills
+The active skill registry is built in `internal/bootstrap/skills.go`. Skill names are stable v1.0 contract identifiers and must keep the `<domain>.<action>` format.
 
-- `doctor.run`
+## Registered Skills
+
+### AI
+
+- `ai.explain`
+
+### Auth
+
+- `auth.login`
 - `auth.validate`
 - `auth.whoami`
+
+### Cost
+
+- `cost.focus_report`
+- `cost.quick_scan`
+
+### Doctor
+
+- `doctor.auth`
+- `doctor.k8s`
+- `doctor.run`
+
+### Infrastructure
+
+- `infra.generate_network`
+
+### Inventory
+
 - `inventory.scan`
 - `inventory.summary`
+
+### Kubernetes
+
 - `k8s.list_clusters`
-- `ai.explain`
-- `ai.generate_terraform`
-- `infra.generate_network`
-- `diagram.generate`
-- `cost.focus_report`
+
+### Landing Zone
+
+- `landingzone.audit`
+
+### Security
+
 - `security.k8s_audit`
 - `security.iam_audit`
+- `security.identity_posture`
 
 ---
 
+## Provider Notes
+
+- AWS: auth, inventory, Kubernetes, security, and cost paths use AWS SDK adapters where implemented.
+- GCP: auth, inventory, Kubernetes, and cost paths use Google SDK adapters where implemented.
+- OCI: auth, inventory, Kubernetes, and cost paths use OCI SDK adapters where implemented.
+- AI: Gemini is the current AI provider path.
+
+`cost.focus_report` uses:
+
+- AWS Cost Explorer.
+- GCP Cloud Billing BigQuery export through `MULTIX_GCP_BILLING_DATASET=<project>.<dataset>.<table>`.
+- OCI Usage API through `MULTIX_OCI_TENANCY_OCID=<tenancy_ocid>`.
+
 ## Rules
 
-- Keep names stable
-- Use `<domain>.<action>`
-- Prefer provider-agnostic names
-- Document new skills here when added
+- Keep names stable once shipped.
+- Use `<domain>.<action>`.
+- Prefer provider-agnostic names.
+- Register each skill exactly once in `internal/bootstrap/skills.go`.
+- Document new skills here when added.
+- Keep business behavior inside application skills, not Cobra handlers.

--- a/docs/standards/contracts.md
+++ b/docs/standards/contracts.md
@@ -20,9 +20,9 @@ Three packages form the entire stable extension surface:
 
 > Note on `internal/`: today these packages live under `internal/` because
 > the project hasn't carved out a public Go module path yet. Once that
-> happens (planned for the v1.0 release alongside #20 plugins), they will
-> migrate to a stable import path. The contract semantics are already
-> v1.0; only the import path is in flux.
+> happens, they will migrate to a stable import path. The contract semantics
+> are already v1.0; only the import path is in flux. Plugin implementation is
+> tracked separately under issue #20 and ADR 0008.
 
 ## Semver promise (v1.0+)
 

--- a/docs/testing-playbook.md
+++ b/docs/testing-playbook.md
@@ -1,0 +1,266 @@
+# MULTIX Testing Playbook
+
+This is the caderno de teste for validating MULTIX locally before opening or merging a PR.
+
+## 1. Baseline
+
+Start from a clean tree:
+
+```bash
+git status --short --branch
+```
+
+Expected:
+
+```text
+## <branch>...origin/<branch>
+```
+
+No modified or untracked files should appear unless they are part of the PR.
+
+## 2. Toolchain
+
+Check Go and module metadata:
+
+```bash
+go version
+go env GOPATH GOMOD
+go list ./...
+```
+
+Expected:
+
+- Go version is compatible with `go.mod`.
+- `GOMOD` points to this repository's `go.mod`.
+- `go list ./...` exits successfully.
+
+## 3. Unit And Contract Tests
+
+Run the same core checks used by CI:
+
+```bash
+test -z "$(gofmt -l .)"
+go test ./...
+go vet ./...
+```
+
+Expected:
+
+- No gofmt output.
+- All packages pass tests.
+- Vet exits cleanly.
+
+## 4. Full Local Gate
+
+Run the repository gate:
+
+```bash
+make all
+make build-cross
+git diff --check
+```
+
+Expected:
+
+- `make all` runs clean, fmt, vet, tidy, test, and native build.
+- `make build-cross` creates Linux and Darwin amd64/arm64 binaries.
+- `git diff --check` reports no whitespace errors.
+
+`make all` and `make build-cross` create files under `build/`. If they are not part of your PR, clean them before committing:
+
+```bash
+rm build/multix-darwin-amd64 build/multix-darwin-arm64 build/multix-linux-amd64 build/multix-linux-arm64
+git checkout -- build/multix
+```
+
+## 5. Race Gate
+
+Run this for changes touching runtime, registry, adapters, provider clients, request IDs, or shared state:
+
+```bash
+make test-race
+```
+
+Expected:
+
+- All tests pass with the race detector.
+- No data race report appears.
+
+## 6. Runtime Smoke Test
+
+Build and start the local runtime:
+
+```bash
+make build
+./build/multix serve --port 8080
+```
+
+In another terminal:
+
+```bash
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/tools
+curl -s http://localhost:8080/capabilities
+curl -s http://localhost:8080/metrics
+```
+
+Expected:
+
+- `/health` returns service status.
+- `/tools` returns registered tool manifests.
+- `/capabilities` returns runtime capabilities and providers.
+- `/metrics` returns Prometheus text exposition.
+
+## 7. Execute Smoke Test
+
+Run a request through `/execute`:
+
+```bash
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -H "X-Request-ID: test-auth-validate" \
+  -d '{
+    "skill": "auth.validate",
+    "provider": "aws",
+    "params": {}
+  }'
+```
+
+Expected:
+
+- The response is JSON.
+- The runtime does not panic.
+- If local cloud credentials are absent, the error is explicit and contained in the response envelope.
+
+Unknown skill check:
+
+```bash
+curl -i -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{"skill":"missing.skill"}'
+```
+
+Expected:
+
+- HTTP status is `404`.
+- Response body is an error envelope.
+
+## 8. Cost Focus Report Checks
+
+AWS:
+
+```bash
+./build/multix auth validate --provider aws --output json
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "cost.focus_report",
+    "params": {
+      "providers": ["aws"],
+      "period": "current_month"
+    }
+  }'
+```
+
+GCP without billing export configured:
+
+```bash
+unset MULTIX_GCP_BILLING_DATASET
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "cost.focus_report",
+    "params": {
+      "providers": ["gcp"],
+      "period": "current_month"
+    }
+  }'
+```
+
+Expected:
+
+- Provider is `gcp`.
+- `supported` is true.
+- `reason` explains that BigQuery export is not configured.
+
+GCP with billing export configured:
+
+```bash
+export MULTIX_GCP_BILLING_DATASET=<project>.<dataset>.<table>
+```
+
+Prerequisites:
+
+- Cloud Billing BigQuery export enabled.
+- Runtime identity has `roles/bigquery.dataViewer` on the export dataset.
+
+OCI without tenancy configured:
+
+```bash
+unset MULTIX_OCI_TENANCY_OCID
+curl -s -X POST http://localhost:8080/execute \
+  -H "Content-Type: application/json" \
+  -d '{
+    "skill": "cost.focus_report",
+    "params": {
+      "providers": ["oci"],
+      "period": "current_month"
+    }
+  }'
+```
+
+Expected:
+
+- Provider is `oci`.
+- `supported` is true.
+- `reason` explains that `MULTIX_OCI_TENANCY_OCID` is not configured.
+
+OCI with Usage API configured:
+
+```bash
+export MULTIX_OCI_TENANCY_OCID=<tenancy_ocid>
+```
+
+Prerequisites:
+
+- Cost and Usage Reports enabled.
+- IAM allows usage-budgets read access in tenancy.
+
+## 9. CLI Smoke Matrix
+
+These commands should render JSON or explicit provider errors:
+
+```bash
+./build/multix version
+./build/multix auth validate --provider aws --output json
+./build/multix auth whoami --provider gcp --output json
+./build/multix inventory list --provider aws --service compute --output json
+./build/multix inventory list --provider gcp --service storage --output json
+./build/multix inventory list --provider oci --service compute --output json
+./build/multix k8s clusters --provider aws --output json
+./build/multix ai explain "Explain this CLI" --output json
+```
+
+Expected:
+
+- Commands do not panic.
+- Missing local credentials produce actionable errors.
+- JSON output stays machine-readable.
+
+## 10. PR Readiness
+
+Before pushing:
+
+```bash
+git status --short --branch
+git diff --stat
+git diff --check
+```
+
+PR body should include:
+
+- Summary of changed docs or behavior.
+- Decisions and guard-rails.
+- Validation commands run.
+- `Closes #N` only when the issue is fully delivered.
+- `Refs #N` or `Part of #N` for partial or design-only work.

--- a/project/PROJECT_ROADMAP.md
+++ b/project/PROJECT_ROADMAP.md
@@ -1,40 +1,60 @@
-# MULTIX Roadmap Structure
+# MULTIX Product Roadmap
 
-## 1. Project Name Options
-- [Your project name options here]
+This roadmap mirrors the GitHub Project `MULTIX Product Roadmap` and the repository state after the v1.0 beta hardening work.
 
-## 2. Description
-- [A short description of the project]
+## Product Direction
 
-## 3. Project Type/Layout
-- [Details about the type/layout of the project]
+MULTIX is a skills-first multi-cloud runtime:
 
-## 4. Custom Fields
-- [List any custom fields]
+- CLI for humans.
+- Local HTTP runtime for agents and automation.
+- Stable skill and provider contracts.
+- Future MCP-based plugin federation.
 
-## 5. Views
-- [Outline the views of the project]
+## Delivered
 
-## 6. Labels
-- [Include labels used in the project]
+- v0.1 foundation: Go module, Cobra, Makefile, repository standards.
+- v0.2 skills-first runtime: skill contract, registry, executor, agent tool manifests.
+- v0.3 real auth: AWS and GCP validation/whoami paths.
+- v0.4 runtime: `multix serve`, `/health`, `/tools`, `/execute`, `/capabilities`.
+- v0.5 inventory: AWS/GCP/OCI inventory paths.
+- v0.6 Kubernetes: EKS/GKE/OKE list-cluster paths.
+- v0.7 operational skills: doctor, landing zone, identity posture, cost quick scan.
+- v0.8/v0.10 AI-assisted skills: network generation, Kubernetes audit, IAM audit.
+- v0.9 FinOps: FOCUS-aligned `cost.focus_report` for AWS, GCP, and OCI.
+- v1.0 stabilization: public contracts, ADRs, governance docs, CI hardening.
 
-## 7. Milestones
-- [Define milestones for the project]
+## Open
 
-## 8. Epics
-- [List epics that are considered in the roadmap]
+- #20 Plugin story and extension model implementation.
+- #21 Enterprise Skill Catalog decision remains intentionally deferred unless reopened by the maintainer.
 
-## 9. Initial Issues
-- [Describe the initial issues that will be tackled]
+## Governance Rules
 
-## 10. Done/In-Progress/Next/Later Population
-- [Summarize how each status will be populated]
+- Every non-trivial change ships through a branch and PR.
+- PR bodies should include summary, decisions, validation, and linked issue.
+- Use `Closes #N` only when the issue is fully delivered.
+- Use `Refs #N` or `Part of #N` for design-only or partial work.
+- Do not mark Project items `Done` until the closing PR is merged.
+- Keep ADRs historical; add a new ADR for a new architecture decision instead of rewriting an accepted one.
 
-## 11. Governance Rules
-- [Outline the rules for governance in the project]
+## Validation Gate
 
-## 12. Weekly Operating Ritual
-- [Describe the weekly operating ritual]
+Minimum local gate before PR:
 
-## 13. Stretch Vision
-- [Discuss the stretch vision for the project]
+```bash
+go test ./...
+go vet ./...
+make all
+make build-cross
+git diff --check
+```
+
+Use `make test-race` for shared runtime, registry, adapter, or concurrency-sensitive changes.
+
+## Stretch Vision
+
+- MCP server exposing the local skill registry.
+- MCP client/plugin loader for external tool servers.
+- Namespaced remote tools with manifest validation.
+- Provider-aware golden paths for enterprise operations.


### PR DESCRIPTION
## Summary
- Refreshes README, docs index, runtime docs, skills catalog, roadmap, contracts note, and agent command guidance for the current post-v1.0-beta state.
- Adds `docs/testing-playbook.md` as a caderno de teste with local gates, runtime smoke tests, provider checks, `cost.focus_report` scenarios, and PR readiness steps.
- Clarifies that ADR 0008 delivered the plugin design while issue #20 remains open for MCP server/client implementation.

## Decisions
- Kept this as a documentation-only change.
- Did not change Go behavior, runtime endpoints, skills, Makefile targets, or provider logic.
- Kept ADRs historical and updated only the docs that point readers at the current state.

## Validation
- `test -z "$(gofmt -l .)"`
- `go test ./...`
- `make all`
- `make build-cross`
- `git diff --check`

Refs #20
